### PR TITLE
Handle missing party window frames in HeroHelper

### DIFF
--- a/Widgets/HeroHelper.py
+++ b/Widgets/HeroHelper.py
@@ -1382,7 +1382,14 @@ def draw_frame_content(content_frame_id):
     if selected_tab == Tabs.party_default:
         return
 
-    left, top, right, bottom = UIManager.GetFrameCoords(content_frame_id)
+    if not content_frame_id:
+        return
+
+    frame_coords = UIManager.GetFrameCoords(content_frame_id)
+    if not frame_coords:
+        return
+
+    left, top, right, bottom = frame_coords
     width, height = right - left, bottom - top
 
     UIManager().DrawFrame(content_frame_id, Utils.RGBToColor(0, 0, 0, 255))
@@ -1422,8 +1429,15 @@ def draw_embedded_window():
         content_frame_id = explorable_content_frame_id
     else:
         content_frame_id = outpost_content_frame_id
-    
-    left, top, right, bottom = UIManager.GetFrameCoords(parent_frame_id)
+
+    if not content_frame_id:
+        return
+
+    parent_coords = UIManager.GetFrameCoords(parent_frame_id)
+    if not parent_coords:
+        return
+
+    left, top, right, bottom = parent_coords
     sidebar_width = 30
     sidebar_height = bottom - top
 


### PR DESCRIPTION
## Summary
- guard the HeroHelper UI embedding against missing or unready party window frames
- skip drawing when frame coordinates are unavailable to avoid crashes during map transitions

## Testing
- python -m compileall Widgets/HeroHelper.py

------
https://chatgpt.com/codex/tasks/task_e_68cb060ee658832ea9214fa49e289c15