### PR TITLE
Fix PyQuishAI outpost metadata for Maguuma, Kryta, and Shiverpeaks maps

### DIFF
--- a/Bots/aC_Scripts/PyQuishAI_maps/Proph_Kryta/CursedLands.py
+++ b/Bots/aC_Scripts/PyQuishAI_maps/Proph_Kryta/CursedLands.py
@@ -42,10 +42,12 @@ CursedLands = [
 ]
 
 CursedLands_outpost_path = [
-    (1683, -1594), (4600, -27863)
+    (-4908.0, 17096.0),
+    (-5198.0, 16120.0),
+    (-5483.0, 15161.0)
 ]
 
 CursedLands_ids = {
-    "outpost_id": None,
+    "outpost_id": 138,
     "map_id": 56
 }

--- a/Bots/aC_Scripts/PyQuishAI_maps/Proph_Kryta/TheBlackCurtain.py
+++ b/Bots/aC_Scripts/PyQuishAI_maps/Proph_Kryta/TheBlackCurtain.py
@@ -254,10 +254,12 @@ TheBlackCurtain = [
 ]
 
 TheBlackCurtain_outpost_path = [
-    (-5057.52, 17188.52), (-5205.00, 15562.00)
+    (-4908.0, 17096.0),
+    (-5198.0, 16120.0),
+    (-5483.0, 15161.0)
 ]
 
 TheBlackCurtain_ids = {
-    "outpost_id": None,
-    "map_id": None
+    "outpost_id": 138,
+    "map_id": 18
 }

--- a/Bots/aC_Scripts/PyQuishAI_maps/Proph_Maguuma/DryTop.py
+++ b/Bots/aC_Scripts/PyQuishAI_maps/Proph_Maguuma/DryTop.py
@@ -47,10 +47,11 @@ DryTop = [
 ]
 
 DryTop_outpost_path = [
-    (1683, -1594), (4600, -27863)
+    (-14398.0, 937.0),
+    (-15374.0, 194.0)
 ]
 
 DryTop_ids = {
-    "outpost_id": None,
+    "outpost_id": 139,
     "map_id": 47
 }

--- a/Bots/aC_Scripts/PyQuishAI_maps/Proph_Maguuma/MamnoonLagoon.py
+++ b/Bots/aC_Scripts/PyQuishAI_maps/Proph_Maguuma/MamnoonLagoon.py
@@ -69,10 +69,12 @@ MamnoonLagoon = [
 ]
 
 MamnoonLagoon_outpost_path = [
-    (1683, -1594), (4600, -27863)
+    (4351.0, -9980.0),
+    (3389.0, -9547.0),
+    (2782.0, -9331.0)
 ]
 
 MamnoonLagoon_ids = {
-    "outpost_id": None,
-    "map_id": None
+    "outpost_id": 140,
+    "map_id": 42
 }

--- a/Bots/aC_Scripts/PyQuishAI_maps/Proph_Maguuma/TheFalls.py
+++ b/Bots/aC_Scripts/PyQuishAI_maps/Proph_Maguuma/TheFalls.py
@@ -249,10 +249,11 @@ TheFalls = [
 ]
 
 TheFalls_outpost_path = [
-    (1683, -1594), (4600, -27863)
+    (-14596.0, 773.0),
+    (-15310.0, 191.0)
 ]
 
 TheFalls_ids = {
-    "outpost_id": None,
-    "map_id": None
+    "outpost_id": 139,
+    "map_id": 46
 }

--- a/Bots/aC_Scripts/PyQuishAI_maps/Proph_SouthernShiverpeaks/DreadnoughtsDrift.py
+++ b/Bots/aC_Scripts/PyQuishAI_maps/Proph_SouthernShiverpeaks/DreadnoughtsDrift.py
@@ -47,10 +47,11 @@ DreadnoughtsDrift = [
 ]
 
 DreadnoughtsDrift_outpost_path = [
-    (1683, -1594), (4600, -27863)
+    (-8596.0, 33555.0),
+    (-8450.0, 33150.0)
 ]
 
 DreadnoughtsDrift_ids = {
-    "outpost_id": None,
+    "outpost_id": 133,
     "map_id": 97
 }

--- a/Bots/aC_Scripts/PyQuishAI_maps/Proph_SouthernShiverpeaks/LornarsPass.py
+++ b/Bots/aC_Scripts/PyQuishAI_maps/Proph_SouthernShiverpeaks/LornarsPass.py
@@ -140,10 +140,11 @@ LornarsPass = [
 ]
 
 LornarsPass_outpost_path = [
-    (1683, -1594), (4600, -27863)
+    (-8596.0, 33555.0),
+    (-8450.0, 33150.0)
 ]
 
 LornarsPass_ids = {
-    "outpost_id": None,
+    "outpost_id": 133,
     "map_id": 90
 }


### PR DESCRIPTION
## Summary
- wire PyQuishAI map metadata for Mamnoon Lagoon, Dry Top, and The Falls to their correct outposts and pathing coordinates
- update Cursed Lands and The Black Curtain to launch from Temple of the Ages with accurate map identifiers
- align Lornar's Pass and Dreadnought's Drift with Beacon's Perch routing so PyQuishAI reaches the intended hubs

## Testing
- python -m compileall Bots/aC_Scripts/PyQuishAI_maps/Proph_Maguuma Bots/aC_Scripts/PyQuishAI_maps/Proph_Kryta Bots/aC_Scripts/PyQuishAI_maps/Proph_SouthernShiverpeaks

------
https://chatgpt.com/codex/tasks/task_e_68ce5ac27eac832ea819ea0cfef94426