### PR TITLE
Add missing PyQuishAI vanquish map list

### DIFF
--- a/Bots/aC_Scripts/PyQuishAI_maps/missing_vanquishable_maps.md
+++ b/Bots/aC_Scripts/PyQuishAI_maps/missing_vanquishable_maps.md
@@ -1,0 +1,84 @@
+# Missing PyQuishAI vanquish map scripts
+
+This list was generated from the Guild Wars Wiki [Vanquisher](https://wiki.guildwars.com/wiki/Vanquisher) tables and cross-referenced with the existing files under `Bots/aC_Scripts/PyQuishAI_maps`. It only includes areas marked as vanquishable.
+
+## Prophecies
+### Crystal Desert
+- Prophet's Path
+
+### Southern Shiverpeaks
+- Frozen Forest
+- Icedome
+- Mineral Springs
+- Tasca's Demise
+
+### Kryta
+- Kessex Peak
+- Majesty's Rest
+- Nebo Terrace
+- North Kryta Province
+- Stingray Strand
+- Talmark Wilderness
+- Tears of the Fallen
+- Watchtower Coast
+
+### Maguuma Jungle
+- Reed Bog
+
+### Northern Shiverpeaks
+- Anvil Rock
+- Griffon's Mouth
+- Iron Horse Mine
+
+### Ascalon
+- Ascalon Foothills
+- Diessa Lowlands
+- Dragon's Gullet
+- Eastern Frontier
+- Flame Temple Corridor
+- Old Ascalon
+- Pockmark Flats
+- The Breach
+
+## Factions
+### Shing Jea Island
+- Zen Daijun (explorable area)
+
+### The Jade Sea
+- Boreas Seabed (explorable area)
+- Gyala Hatchery (explorable area)
+- Unwaking Waters (explorable area)
+
+### Echovald Forest
+- Arborstone (explorable area)
+- The Eternal Grove (explorable area)
+
+### Kaineng City
+- Nahpui Quarter (explorable area)
+- Raisu Palace (explorable area)
+- Sunjiang District (explorable area)
+- Tahnnakai Temple (explorable area)
+
+## Nightfall
+### The Desolation
+- Crystal Overlook
+- Joko's Domain
+- Poisoned Outcrops
+- The Alkali Pan
+- The Ruptured Heart
+- The Shattered Ravines
+- The Sulfurous Wastes
+
+## Eye of the North
+### Far Shiverpeaks
+- Bjora Marches
+- Drakkar Lake
+- Jaga Moraine
+
+### Tarnished Coast
+- Sparkfly Swamp
+- Verdant Cascades
+
+### Charr Homelands
+- Grothmar Wardowns
+- Sacnoth Valley


### PR DESCRIPTION
## Summary
- add a generated markdown list of vanquishable areas lacking map scripts under `Bots/aC_Scripts/PyQuishAI_maps`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce94fc5c80832e967fcdeb1e83ae4a