### PR TITLE
Add missing vanquishable map coverage report

### DIFF
--- a/Bots/aC_Scripts/PyQuishAI_maps/MISSING_MAPS.md
+++ b/Bots/aC_Scripts/PyQuishAI_maps/MISSING_MAPS.md
@@ -1,0 +1,126 @@
+# Missing Vanquishable Map Scripts
+
+_Generated 2025-09-20 11:58 UTC using Guild Wars Wiki category data._
+
+## Coverage Summary
+
+| Region | Scripts Present | Total Vanquishable Areas | Missing | Directory Exists? |
+| --- | ---: | ---: | ---: | --- |
+| Eye of the North – Charr Homelands | 1 | 3 | 2 | Yes |
+| Eye of the North – Far Shiverpeaks | 3 | 6 | 4 | Yes |
+| Eye of the North – Tarnished Coast | 4 | 6 | 2 | Yes |
+| Factions – Echovald Forest | 6 | 7 | 1 | Yes |
+| Factions – Kaineng City | 10 | 10 | 0 | Yes |
+| Factions – Shing Jea Island | 8 | 7 | 0 | Yes |
+| Factions – The Jade Sea | 8 | 8 | 0 | Yes |
+| Nightfall – The Desolation | 0 | 7 | 7 | No |
+| Nightfall – Istan | 7 | 7 | 0 | Yes |
+| Nightfall – Kourna | 10 | 9 | 0 | Yes |
+| Nightfall – Vabbi | 9 | 10 | 1 | Yes |
+| Prophecies – Ascalon | 1 | 9 | 8 | Yes |
+| Prophecies – Crystal Desert | 5 | 7 | 2 | Yes |
+| Prophecies – Kryta | 3 | 13 | 10 | Yes |
+| Prophecies – Maguuma Jungle | 5 | 8 | 3 | Yes |
+| Prophecies – Northern Shiverpeaks | 1 | 5 | 4 | Yes |
+| Prophecies – Ring of Fire Islands | 1 | 1 | 0 | Yes |
+| Prophecies – Southern Shiverpeaks | 9 | 12 | 4 | Yes |
+
+## Region Details
+
+### Eye of the North – Charr Homelands (2 missing of 3)
+- Grothmar Wardowns (`map_id=649`)
+- Sacnoth Valley (`map_id=651`)
+
+### Eye of the North – Far Shiverpeaks (4 missing of 6)
+- Bjora Marches (`map_id=482`)
+- Drakkar Lake (`map_id=513`)
+- Jaga Moraine (`map_id=546`)
+- Varajar Fells (`map_id=708`)
+
+### Eye of the North – Tarnished Coast (2 missing of 6)
+- Sparkfly Swamp (`map_id=558`)
+- Verdant Cascades (`map_id=566`)
+
+### Factions – Echovald Forest (1 missing of 7)
+- Mourning Veil Falls (`map_id=209`)
+
+### Nightfall – The Desolation (7 missing of 7)
+> **Note:** No script directory exists yet for this region.
+- Joko's Domain (`map_id=437`)
+- The Ruptured Heart (`map_id=439`)
+- The Shattered Ravines (`map_id=441`)
+- Poisoned Outcrops (`map_id=443`)
+- The Sulfurous Wastes (`map_id=444`)
+- The Alkali Pan (`map_id=446`)
+- Crystal Overlook (`map_id=448`)
+
+### Nightfall – Vabbi (1 missing of 10)
+- Garden of Seborhin (`map_id=394`)
+
+### Prophecies – Ascalon (8 missing of 9)
+- Diessa Lowlands (`map_id=13`)
+- Old Ascalon (`map_id=33`)
+- The Breach (`map_id=102`)
+- Ascalon Foothills (`map_id=103`)
+- Pockmark Flats (`map_id=104`)
+- Dragon's Gullet (`map_id=105`)
+- Flame Temple Corridor (`map_id=106`)
+- Eastern Frontier (`map_id=107`)
+
+### Prophecies – Crystal Desert (2 missing of 7)
+- The Scar (`map_id=108`)
+- Prophet's Path (`map_id=113`)
+
+### Prophecies – Kryta (10 missing of 13)
+- Talmark Wilderness (`map_id=17`)
+- The Black Curtain (`map_id=18`)
+- Tears of the Fallen (`map_id=53`)
+- North Kryta Province (`map_id=58`)
+- Nebo Terrace (`map_id=59`)
+- Majesty's Rest (`map_id=60`)
+- Watchtower Coast (`map_id=62`)
+- Stingray Strand (`map_id=63`)
+- Kessex Peak (`map_id=64`)
+- Talmark Wilderness (War in Kryta) (`map_id=837`)
+
+### Prophecies – Maguuma Jungle (3 missing of 8)
+- Mamnoon Lagoon (`map_id=42`)
+- Reed Bog (`map_id=45`)
+- The Falls (`map_id=46`)
+
+### Prophecies – Northern Shiverpeaks (4 missing of 5)
+- Griffon's Mouth (`map_id=27`)
+- Iron Horse Mine (`map_id=88`)
+- Anvil Rock (`map_id=89`)
+- Deldrimor Bowl (`map_id=100`)
+
+### Prophecies – Southern Shiverpeaks (4 missing of 12)
+- Icedome (`map_id=87`)
+- Tasca's Demise (`map_id=92`)
+- Mineral Springs (`map_id=96`)
+- Frozen Forest (`map_id=98`)
+
+## Not Mapped (missing map_id in enums)
+These vanquishable instances are listed on the wiki but are not present in `explorable_name_to_id`. They often correspond to event-exclusive versions such as War in Kryta or Winds of Change.
+
+- Bahdok Caverns
+- Bukdek Byway (Winds of Change)
+- Cursed Lands (War in Kryta)
+- Haiju Lagoon (Winds of Change)
+- Kessex Peak (War in Kryta)
+- Minister Cho's Estate (Winds of Change)
+- Minister Cho's Estate (explorable area)
+- Morostav Trail (Winds of Change)
+- Nebo Terrace (War in Kryta)
+- North Kryta Province (War in Kryta)
+- Pongmei Valley (Winds of Change)
+- Rhea's Crater (Winds of Change)
+- Scoundrel's Rise (War in Kryta)
+- Shadow's Passage (Winds of Change)
+- Shenzun Tunnels (Winds of Change)
+- Silent Surf (Winds of Change)
+- Sunjiang District (Winds of Change)
+- The Black Curtain (War in Kryta)
+- Twin Serpent Lakes (War in Kryta)
+- Watchtower Coast (War in Kryta)
+- Zen Daijun (Winds of Change)


### PR DESCRIPTION
## Summary
- generate a coverage report of vanquishable areas versus existing PyQuishAI map scripts
- record missing map names, map IDs, and region coverage in Bots/aC_Scripts/PyQuishAI_maps/MISSING_MAPS.md
- note wiki-listed variants that lack map IDs in the local enums

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ce94fc5c80832e967fcdeb1e83ae4a