### PR TITLE
Guard chat history polling during map transitions

### DIFF
--- a/Widgets/Chat Log Saver.py
+++ b/Widgets/Chat Log Saver.py
@@ -236,6 +236,15 @@ def process_chat_updates() -> None:
     if not logging_enabled:
         return
 
+    if (
+        GLOBAL_CACHE.Map.IsMapLoading()
+        or GLOBAL_CACHE.Player.InCharacterSelectScreen()
+    ):
+        pending_chat_request = False
+        chat_queue.clear()
+        chat_request_timer.Reset()
+        return
+
     if not pending_chat_request and chat_request_timer.HasElapsed(CHAT_REQUEST_INTERVAL_MS):
         chat_queue.add_action(request_chat_history_action)
         chat_request_timer.Reset()


### PR DESCRIPTION
## Summary
- prevent chat history requests from running while the map is loading or the player is at the character select screen
- clear pending chat actions and reset the timer so polling resumes only after the world is ready

## Testing
- python -m compileall "Widgets/Chat Log Saver.py"


------
https://chatgpt.com/codex/tasks/task_e_68d1433496d0832e8db921ae4bd5065c