### PR TITLE
Enable enemy data capture by default

### DIFF
--- a/Widgets/Enemy Data Capture.py
+++ b/Widgets/Enemy Data Capture.py
@@ -121,7 +121,7 @@ class EnemyObservationCollector:
       right after zoning when names are still loading.
     """
     def __init__(self):
-        self.enabled = False
+        self.enabled = True
         self.sample_interval_ms = 1000
         self.min_move_delta = 500              # don't re-log if agent hasn't moved ~>500 units
         self.max_buffer = 200                  # flush to disk every N records


### PR DESCRIPTION
## Summary
- default the enemy data capture widget collector to start enabled so logging begins immediately

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d692622428832e9adda9d20e1de787