### PR TITLE
Handle armor modifiers in item compare

### DIFF
--- a/Legacy code and tests/ItemCompare.py
+++ b/Legacy code and tests/ItemCompare.py
@@ -41,190 +41,212 @@ def add_modifier(modifier):
 
 
 ARMOR_MODIFIERS_HEX_DATA = [
-    (0x21E8, 0x0001, 0x0000, 0x0000, "Rune of Minor Fast Casting"),  # 21E80001
-    (0x21E8, 0x0002, 0x0000, 0x0000, "Rune of Major Fast Casting"),  # 21E80002
-    (0x21E8, 0x0003, 0x0000, 0x0000, "Rune of Superior Fast Casting"),  # 21E80003
-    (0x21E8, 0x0101, 0x0000, 0x0000, "Rune of Minor Illusion Magic"),  # 21E80101
-    (0x21E8, 0x0102, 0x0000, 0x0000, "Rune of Major Illusion Magic"),  # 21E80102
-    (0x21E8, 0x0103, 0x0000, 0x0000, "Rune of Superior Illusion Magic"),  # 21E80103
-    (0x21E8, 0x0201, 0x0000, 0x0000, "Rune of Minor Domination Magic"),  # 21E80201
-    (0x21E8, 0x0202, 0x0000, 0x0000, "Rune of Major Domination Magic"),  # 21E80202
-    (0x21E8, 0x0203, 0x0000, 0x0000, "Rune of Superior Domination Magic"),  # 21E80203
-    (0x21E8, 0x0301, 0x0000, 0x0000, "Rune of Minor Inspiration Magic"),  # 21E80301
-    (0x21E8, 0x0302, 0x0000, 0x0000, "Rune of Major Inspiration Magic"),  # 21E80302
-    (0x21E8, 0x0303, 0x0000, 0x0000, "Rune of Superior Inspiration Magic"),  # 21E80303
-    (0x21E8, 0x0401, 0x0000, 0x0000, "Rune of Minor Blood Magic"),  # 21E80401
-    (0x21E8, 0x0402, 0x0000, 0x0000, "Rune of Major Blood Magic"),  # 21E80402
-    (0x21E8, 0x0403, 0x0000, 0x0000, "Rune of Superior Blood Magic"),  # 21E80403
-    (0x21E8, 0x0501, 0x0000, 0x0000, "Rune of Minor Death Magic"),  # 21E80501
-    (0x21E8, 0x0502, 0x0000, 0x0000, "Rune of Major Death Magic"),  # 21E80502
-    (0x21E8, 0x0503, 0x0000, 0x0000, "Rune of Superior Death Magic"),  # 21E80503
-    (0x21E8, 0x0601, 0x0000, 0x0000, "Rune of Minor Soul Reaping"),  # 21E80601
-    (0x21E8, 0x0602, 0x0000, 0x0000, "Rune of Major Soul Reaping"),  # 21E80602
-    (0x21E8, 0x0603, 0x0000, 0x0000, "Rune of Superior Soul Reaping"),  # 21E80603
-    (0x21E8, 0x0701, 0x0000, 0x0000, "Rune of Minor Curses"),  # 21E80701
-    (0x21E8, 0x0702, 0x0000, 0x0000, "Rune of Major Curses"),  # 21E80702
-    (0x21E8, 0x0703, 0x0000, 0x0000, "Rune of Superior Curses"),  # 21E80703
-    (0x21E8, 0x0801, 0x0000, 0x0000, "Rune of Minor Air Magic"),  # 21E80801
-    (0x21E8, 0x0802, 0x0000, 0x0000, "Rune of Major Air Magic"),  # 21E80802
-    (0x21E8, 0x0803, 0x0000, 0x0000, "Rune of Superior Air Magic"),  # 21E80803
-    (0x21E8, 0x0901, 0x0000, 0x0000, "Rune of Minor Earth Magic"),  # 21E80901
-    (0x21E8, 0x0902, 0x0000, 0x0000, "Rune of Major Earth Magic"),  # 21E80902
-    (0x21E8, 0x0903, 0x0000, 0x0000, "Rune of Superior Earth Magic"),  # 21E80903
-    (0x21E8, 0x0A01, 0x0000, 0x0000, "Rune of Minor Fire Magic"),  # 21E80A01
-    (0x21E8, 0x0A02, 0x0000, 0x0000, "Rune of Major Fire Magic"),  # 21E80A02
-    (0x21E8, 0x0A03, 0x0000, 0x0000, "Rune of Superior Fire Magic"),  # 21E80A03
-    (0x21E8, 0x0B01, 0x0000, 0x0000, "Rune of Minor Water Magic"),  # 21E80B01
-    (0x21E8, 0x0B02, 0x0000, 0x0000, "Rune of Major Water Magic"),  # 21E80B02
-    (0x21E8, 0x0B03, 0x0000, 0x0000, "Rune of Superior Water Magic"),  # 21E80B03
-    (0x21E8, 0x0C01, 0x0000, 0x0000, "Rune of Minor Energy Storage"),  # 21E80C01
-    (0x21E8, 0x0C02, 0x0000, 0x0000, "Rune of Major Energy Storage"),  # 21E80C02
-    (0x21E8, 0x0C03, 0x0000, 0x0000, "Rune of Superior Energy Storage"),  # 21E80C03
-    (0x21E8, 0x0D01, 0x0000, 0x0000, "Rune of Minor Healing Prayers"),  # 21E80D01
-    (0x21E8, 0x0D02, 0x0000, 0x0000, "Rune of Major Healing Prayers"),  # 21E80D02
-    (0x21E8, 0x0D03, 0x0000, 0x0000, "Rune of Superior Healing Prayers"),  # 21E80D03
-    (0x21E8, 0x0E01, 0x0000, 0x0000, "Rune of Minor Smiting Prayers"),  # 21E80E01
-    (0x21E8, 0x0E02, 0x0000, 0x0000, "Rune of Major Smiting Prayers"),  # 21E80E02
-    (0x21E8, 0x0E03, 0x0000, 0x0000, "Rune of Superior Smiting Prayers"),  # 21E80E03
-    (0x21E8, 0x0F01, 0x0000, 0x0000, "Rune of Minor Protection Prayers"),  # 21E80F01
-    (0x21E8, 0x0F02, 0x0000, 0x0000, "Rune of Major Protection Prayers"),  # 21E80F02
-    (0x21E8, 0x0F03, 0x0000, 0x0000, "Rune of Superior Protection Prayers"),  # 21E80F03
-    (0x21E8, 0x1001, 0x0000, 0x0000, "Rune of Minor Divine Favor"),  # 21E81001
-    (0x21E8, 0x1002, 0x0000, 0x0000, "Rune of Major Divine Favor"),  # 21E81002
-    (0x21E8, 0x1003, 0x0000, 0x0000, "Rune of Superior Divine Favor"),  # 21E81003
-    (0x21E8, 0x1101, 0x0000, 0x0000, "Rune of Minor Strength"),  # 21E81101
-    (0x21E8, 0x1102, 0x0000, 0x0000, "Rune of Major Strength"),  # 21E81102
-    (0x21E8, 0x1103, 0x0000, 0x0000, "Rune of Superior Strength"),  # 21E81103
-    (0x21E8, 0x1201, 0x0000, 0x0000, "Rune of Minor Axe Mastery"),  # 21E81201
-    (0x21E8, 0x1202, 0x0000, 0x0000, "Rune of Major Axe Mastery"),  # 21E81202
-    (0x21E8, 0x1203, 0x0000, 0x0000, "Rune of Superior Axe Mastery"),  # 21E81203
-    (0x21E8, 0x1301, 0x0000, 0x0000, "Rune of Minor Hammer Mastery"),  # 21E81301
-    (0x21E8, 0x1302, 0x0000, 0x0000, "Rune of Major Hammer Mastery"),  # 21E81302
-    (0x21E8, 0x1303, 0x0000, 0x0000, "Rune of Superior Hammer Mastery"),  # 21E81303
-    (0x21E8, 0x1401, 0x0000, 0x0000, "Rune of Minor Swordsmanship"),  # 21E81401
-    (0x21E8, 0x1402, 0x0000, 0x0000, "Rune of Major Swordsmanship"),  # 21E81402
-    (0x21E8, 0x1403, 0x0000, 0x0000, "Rune of Superior Swordsmanship"),  # 21E81403
-    (0x21E8, 0x1501, 0x0000, 0x0000, "Rune of Minor Tactics"),  # 21E81501
-    (0x21E8, 0x1502, 0x0000, 0x0000, "Rune of Major Tactics"),  # 21E81502
-    (0x21E8, 0x1503, 0x0000, 0x0000, "Rune of Superior Tactics"),  # 21E81503
-    (0x21E8, 0x1601, 0x0000, 0x0000, "Rune of Minor Beast Mastery"),  # 21E81601
-    (0x21E8, 0x1602, 0x0000, 0x0000, "Rune of Major Beast Mastery"),  # 21E81602
-    (0x21E8, 0x1603, 0x0000, 0x0000, "Rune of Superior Beast Mastery"),  # 21E81603
-    (0x21E8, 0x1701, 0x0000, 0x0000, "Rune of Minor Expertise"),  # 21E81701
-    (0x21E8, 0x1702, 0x0000, 0x0000, "Rune of Major Expertise"),  # 21E81702
-    (0x21E8, 0x1703, 0x0000, 0x0000, "Rune of Superior Expertise"),  # 21E81703
-    (0x21E8, 0x1801, 0x0000, 0x0000, "Rune of Minor Wilderness Survival"),  # 21E81801
-    (0x21E8, 0x1802, 0x0000, 0x0000, "Rune of Major Wilderness Survival"),  # 21E81802
-    (0x21E8, 0x1803, 0x0000, 0x0000, "Rune of Superior Wilderness Survival"),  # 21E81803
-    (0x21E8, 0x1901, 0x0000, 0x0000, "Rune of Minor Marksmanship"),  # 21E81901
-    (0x21E8, 0x1902, 0x0000, 0x0000, "Rune of Major Marksmanship"),  # 21E81902
-    (0x21E8, 0x1903, 0x0000, 0x0000, "Rune of Superior Marksmanship"),  # 21E81903
-    (0x21E8, 0x1D01, 0x0000, 0x0000, "Rune of Minor Dagger Mastery"),  # 21E81D01
-    (0x21E8, 0x1D02, 0x0000, 0x0000, "Rune of Major Dagger Mastery"),  # 21E81D02
-    (0x21E8, 0x1D03, 0x0000, 0x0000, "Rune of Superior Dagger Mastery"),  # 21E81D03
-    (0x21E8, 0x1E01, 0x0000, 0x0000, "Rune of Minor Deadly Arts"),  # 21E81E01
-    (0x21E8, 0x1E02, 0x0000, 0x0000, "Rune of Major Deadly Arts"),  # 21E81E02
-    (0x21E8, 0x1E03, 0x0000, 0x0000, "Rune of Superior Deadly Arts"),  # 21E81E03
-    (0x21E8, 0x1F01, 0x0000, 0x0000, "Rune of Minor Shadow Arts"),  # 21E81F01
-    (0x21E8, 0x1F02, 0x0000, 0x0000, "Rune of Major Shadow Arts"),  # 21E81F02
-    (0x21E8, 0x1F03, 0x0000, 0x0000, "Rune of Superior Shadow Arts"),  # 21E81F03
-    (0x21E8, 0x2001, 0x0000, 0x0000, "Rune of Minor Communing"),  # 21E82001
-    (0x21E8, 0x2002, 0x0000, 0x0000, "Rune of Major Communing"),  # 21E82002
-    (0x21E8, 0x2003, 0x0000, 0x0000, "Rune of Superior Communing"),  # 21E82003
-    (0x21E8, 0x2101, 0x0000, 0x0000, "Rune of Minor Restoration Magic"),  # 21E82101
-    (0x21E8, 0x2102, 0x0000, 0x0000, "Rune of Major Restoration Magic"),  # 21E82102
-    (0x21E8, 0x2103, 0x0000, 0x0000, "Rune of Superior Restoration Magic"),  # 21E82103
-    (0x21E8, 0x2201, 0x0000, 0x0000, "Rune of Minor Channeling Magic"),  # 21E82201
-    (0x21E8, 0x2202, 0x0000, 0x0000, "Rune of Major Channeling Magic"),  # 21E82202
-    (0x21E8, 0x2203, 0x0000, 0x0000, "Rune of Superior Channeling Magic"),  # 21E82203
-    (0x21E8, 0x2301, 0x0000, 0x0000, "Rune of Minor Critical Strikes"),  # 21E82301
-    (0x21E8, 0x2302, 0x0000, 0x0000, "Rune of Major Critical Strikes"),  # 21E82302
-    (0x21E8, 0x2303, 0x0000, 0x0000, "Rune of Superior Critical Strikes"),  # 21E82303
-    (0x21E8, 0x2401, 0x0000, 0x0000, "Rune of Minor Spawning Power"),  # 21E82401
-    (0x21E8, 0x2402, 0x0000, 0x0000, "Rune of Major Spawning Power"),  # 21E82402
-    (0x21E8, 0x2403, 0x0000, 0x0000, "Rune of Superior Spawning Power"),  # 21E82403
-    (0x21E8, 0x2501, 0x0000, 0x0000, "Rune of Minor Spear Mastery"),  # 21E82501
-    (0x21E8, 0x2502, 0x0000, 0x0000, "Rune of Major Spear Mastery"),  # 21E82502
-    (0x21E8, 0x2503, 0x0000, 0x0000, "Rune of Superior Spear Mastery"),  # 21E82503
-    (0x21E8, 0x2601, 0x0000, 0x0000, "Rune of Minor Command"),  # 21E82601
-    (0x21E8, 0x2602, 0x0000, 0x0000, "Rune of Major Command"),  # 21E82602
-    (0x21E8, 0x2603, 0x0000, 0x0000, "Rune of Superior Command"),  # 21E82603
-    (0x21E8, 0x2701, 0x0000, 0x0000, "Rune of Minor Motivation"),  # 21E82701
-    (0x21E8, 0x2702, 0x0000, 0x0000, "Rune of Major Motivation"),  # 21E82702
-    (0x21E8, 0x2703, 0x0000, 0x0000, "Rune of Superior Motivation"),  # 21E82703
-    (0x21E8, 0x2801, 0x0000, 0x0000, "Rune of Minor Leadership"),  # 21E82801
-    (0x21E8, 0x2802, 0x0000, 0x0000, "Rune of Major Leadership"),  # 21E82802
-    (0x21E8, 0x2803, 0x0000, 0x0000, "Rune of Superior Leadership"),  # 21E82803
-    (0x21E8, 0x2901, 0x0000, 0x0000, "Rune of Minor Scythe Mastery"),  # 21E82901
-    (0x21E8, 0x2902, 0x0000, 0x0000, "Rune of Major Scythe Mastery"),  # 21E82902
-    (0x21E8, 0x2903, 0x0000, 0x0000, "Rune of Superior Scythe Mastery"),  # 21E82903
-    (0x21E8, 0x2A01, 0x0000, 0x0000, "Rune of Minor Wind Prayers"),  # 21E82A01
-    (0x21E8, 0x2A02, 0x0000, 0x0000, "Rune of Major Wind Prayers"),  # 21E82A02
-    (0x21E8, 0x2A03, 0x0000, 0x0000, "Rune of Superior Wind Prayers"),  # 21E82A03
-    (0x21E8, 0x2B01, 0x0000, 0x0000, "Rune of Minor Earth Prayers"),  # 21E82B01
-    (0x21E8, 0x2B02, 0x0000, 0x0000, "Rune of Major Earth Prayers"),  # 21E82B02
-    (0x21E8, 0x2B03, 0x0000, 0x0000, "Rune of Superior Earth Prayers"),  # 21E82B03
-    (0x21E8, 0x2C01, 0x0000, 0x0000, "Rune of Minor Mysticism"),  # 21E82C01
-    (0x21E8, 0x2C02, 0x0000, 0x0000, "Rune of Major Mysticism"),  # 21E82C02
-    (0x21E8, 0x2C03, 0x0000, 0x0000, "Rune of Superior Mysticism"),  # 21E82C03
-    (0x2408, 0x00C2, 0x0000, 0x0000, "Rune of Minor Vigor"),  # 240800C2
-    (0x2408, 0x00FC, 0x0000, 0x0000, "Rune of Minor Absorption"),  # 240800FC
-    (0x2408, 0x00FD, 0x0000, 0x0000, "Rune of Major Absorption"),  # 240800FD
-    (0x2408, 0x00FE, 0x0000, 0x0000, "Rune of Superior Absorption"),  # 240800FE
-    (0x2408, 0x00FF, 0x0000, 0x0000, "Rune of Minor Vigor"),  # 240800FF
-    (0x2408, 0x0100, 0x0000, 0x0000, "Rune of Major Vigor"),  # 24080100
-    (0x2408, 0x0101, 0x0000, 0x0000, "Rune of Superior Vigor"),  # 24080101
-    (0x2408, 0x01DE, 0x0000, 0x0000, "Vanguard's Insignia"),  # 240801DE
-    (0x2408, 0x01DF, 0x0000, 0x0000, "Infiltrator's Insignia"),  # 240801DF
-    (0x2408, 0x01E0, 0x0000, 0x0000, "Saboteur's Insignia"),  # 240801E0
-    (0x2408, 0x01E1, 0x0000, 0x0000, "Nightstalker's Insignia"),  # 240801E1
-    (0x2408, 0x01E2, 0x0000, 0x0000, "Artificer's Insignia"),  # 240801E2
-    (0x2408, 0x01E3, 0x0000, 0x0000, "Prodigy's Insignia"),  # 240801E3
-    (0x2408, 0x01E4, 0x0000, 0x0000, "Virtuoso's Insignia"),  # 240801E4
-    (0x2408, 0x01E5, 0x0000, 0x0000, "Radiant Insignia"),  # 240801E5
-    (0x2408, 0x01E6, 0x0000, 0x0000, "Survivor Insignia"),  # 240801E6
-    (0x2408, 0x01E7, 0x0000, 0x0000, "Stalwart Insignia"),  # 240801E7
-    (0x2408, 0x01E8, 0x0000, 0x0000, "Brawler's Insignia"),  # 240801E8
-    (0x2408, 0x01E9, 0x0000, 0x0000, "Blessed Insignia"),  # 240801E9
-    (0x2408, 0x01EA, 0x0000, 0x0000, "Herald's Insignia"),  # 240801EA
-    (0x2408, 0x01EB, 0x0000, 0x0000, "Sentry's Insignia"),  # 240801EB
-    (0x2408, 0x01EC, 0x0000, 0x0000, "Tormentor's Insignia"),  # 240801EC
-    (0x2408, 0x01ED, 0x0000, 0x0000, "Undertaker's Insignia"),  # 240801ED
-    (0x2408, 0x01EE, 0x0000, 0x0000, "Bonelace Insignia"),  # 240801EE
-    (0x2408, 0x01EF, 0x0000, 0x0000, "Minion Master's Insignia"),  # 240801EF
-    (0x2408, 0x01F0, 0x0000, 0x0000, "Blighter's Insignia"),  # 240801F0
-    (0x2408, 0x01F1, 0x0000, 0x0000, "Prismatic Insignia"),  # 240801F1
-    (0x2408, 0x01F2, 0x0000, 0x0000, "Hydromancer Insignia"),  # 240801F2
-    (0x2408, 0x01F3, 0x0000, 0x0000, "Geomancer Insignia"),  # 240801F3
-    (0x2408, 0x01F4, 0x0000, 0x0000, "Pyromancer Insignia"),  # 240801F4
-    (0x2408, 0x01F5, 0x0000, 0x0000, "Aeromancer Insignia"),  # 240801F5
-    (0x2408, 0x01F6, 0x0000, 0x0000, "Wanderer's Insignia"),  # 240801F6
-    (0x2408, 0x01F7, 0x0000, 0x0000, "Disciple's Insignia"),  # 240801F7
-    (0x2408, 0x01F8, 0x0000, 0x0000, "Anchorite's Insignia"),  # 240801F8
-    (0x2408, 0x01F9, 0x0000, 0x0000, "Knight's Insignia"),  # 240801F9
-    (0x2408, 0x01FA, 0x0000, 0x0000, "Dreadnought Insignia"),  # 240801FA
-    (0x2408, 0x01FB, 0x0000, 0x0000, "Sentinel's Insignia"),  # 240801FB
-    (0x2408, 0x01FC, 0x0000, 0x0000, "Frostbound Insignia"),  # 240801FC
-    (0x2408, 0x01FD, 0x0000, 0x0000, "Earthbound Insignia"),  # 240801FD
-    (0x2408, 0x01FE, 0x0000, 0x0000, "Pyrebound Insignia"),  # 240801FE
-    (0x2408, 0x01FF, 0x0000, 0x0000, "Stormbound Insignia"),  # 240801FF
-    (0x2408, 0x0200, 0x0000, 0x0000, "Beastmaster's Insignia"),  # 24080200
-    (0x2408, 0x0201, 0x0000, 0x0000, "Scout's Insignia"),  # 24080201
-    (0x2408, 0x0202, 0x0000, 0x0000, "Windwalker Insignia"),  # 24080202
-    (0x2408, 0x0203, 0x0000, 0x0000, "Forsaken Insignia"),  # 24080203
-    (0x2408, 0x0204, 0x0000, 0x0000, "Shaman's Insignia"),  # 24080204
-    (0x2408, 0x0205, 0x0000, 0x0000, "Ghost Forge Insignia"),  # 24080205
-    (0x2408, 0x0206, 0x0000, 0x0000, "Mystic's Insignia"),  # 24080206
-    (0x2408, 0x0207, 0x0000, 0x0000, "Centurion's Insignia"),  # 24080207
-    (0x2408, 0x0208, 0x0000, 0x0000, "Lieutenant's Insignia"),  # 24080208
-    (0x2408, 0x0209, 0x0000, 0x0000, "Stonefist Insignia"),  # 24080209
-    (0x2408, 0x020A, 0x0000, 0x0000, "Bloodstained Insignia"),  # 2408020A
-    (0x2408, 0x0211, 0x0000, 0x0000, "Rune of Attunement"),  # 24080211
-    (0x2408, 0x0212, 0x0000, 0x0000, "Rune of Vitae"),  # 24080212
-    (0x2408, 0x0213, 0x0000, 0x0000, "Rune of Recovery"),  # 24080213
-    (0x2408, 0x0214, 0x0000, 0x0000, "Rune of Restoration"),  # 24080214
-    (0x2408, 0x0215, 0x0000, 0x0000, "Rune of Clarity"),  # 24080215
-    (0x2408, 0x0216, 0x0000, 0x0000, "Rune of Purity"),  # 24080216
+    # region warrior
+    (9224, 505, 1, 249, "Knight's Insignia"),  # 240801F9
+    (9224, 520, 2, 8, "Lieutenant's Insignia"),  # 24080208
+    (9224, 521, 2, 9, "Stonefist Insignia"),  # 24080209
+    (9224, 506, 1, 250, "Dreadnought Insignia"),  # 240801FA
+    (9224, 507, 1, 251, "Sentinel's Insignia"),  # 240801FB
+    (9224, 252, 0, 252, "Rune of Minor Absorption"),  # 240800FC
+    (8680, 5377, 21, 1, "Rune of Minor Tactics"),  # 21E81501
+    (8680, 4353, 17, 1, "Rune of Minor Strength"),  # 21E81101
+    (8680, 4609, 18, 1, "Rune of Minor Axe Mastery"),  # 21E81201
+    (8680, 4865, 19, 1, "Rune of Minor Hammer Mastery"),  # 21E81301
+    (8680, 5121, 20, 1, "Rune of Minor Swordsmanship"),  # 21E81401
+    (9224, 253, 0, 253, "Rune of Major Absorption"),  # 240800FD
+    (8680, 5378, 21, 2, "Rune of Major Tactics"),  # 21E81502
+    (8680, 4354, 17, 2, "Rune of Major Strength"),  # 21E81102
+    (8680, 4610, 18, 2, "Rune of Major Axe Mastery"),  # 21E81202
+    (8680, 4866, 19, 2, "Rune of Major Hammer Mastery"),  # 21E81302
+    (8680, 5122, 20, 2, "Rune of Major Swordsmanship"),  # 21E81402
+    (9224, 254, 0, 254, "Rune of Superior Absorption"),  # 240800FE
+    (8680, 5379, 21, 3, "Rune of Superior Tactics"),  # 21E81503
+    (8680, 4355, 17, 3, "Rune of Superior Strength"),  # 21E81103
+    (8680, 4611, 18, 3, "Rune of Superior Axe Mastery"),  # 21E81203
+    (8680, 4867, 19, 3, "Rune of Superior Hammer Mastery"),  # 21E81303
+    (8680, 5123, 20, 3, "Rune of Superior Swordsmanship"),  # 21E81403
+    # endregion
+    # region ranger
+    (9224, 508, 1, 252, "Frostbound Insignia"),  # 240801FC
+    (9224, 510, 1, 254, "Pyrebound Insignia"),  # 240801FE
+    (9224, 511, 1, 255, "Stormbound Insignia"),  # 240801FF
+    (9224, 513, 2, 1, "Scout's Insignia"),  # 24080201
+    (9224, 509, 1, 253, "Earthbound Insignia"),  # 240801FD
+    (9224, 512, 2, 0, "Beastmaster's Insignia"),  # 24080200
+    (8680, 6145, 24, 1, "Rune of Minor Wilderness Survival"),  # 21E81801
+    (8680, 5889, 23, 1, "Rune of Minor Expertise"),  # 21E81701
+    (8680, 5633, 22, 1, "Rune of Minor Beast Mastery"),  # 21E81601
+    (8680, 6401, 25, 1, "Rune of Minor Marksmanship"),  # 21E81901
+    (8680, 6146, 24, 2, "Rune of Major Wilderness Survival"),  # 21E81802
+    (8680, 5890, 23, 2, "Rune of Major Expertise"),  # 21E81702
+    (8680, 5634, 22, 2, "Rune of Major Beast Mastery"),  # 21E81602
+    (8680, 6402, 25, 2, "Rune of Major Marksmanship"),  # 21E81902
+    (8680, 6147, 24, 3, "Rune of Superior Wilderness Survival"),  # 21E81803
+    (8680, 5891, 23, 3, "Rune of Superior Expertise"),  # 21E81703
+    (8680, 5635, 22, 3, "Rune of Superior Beast Mastery"),  # 21E81603
+    (8680, 6403, 25, 3, "Rune of Superior Marksmanship"),  # 21E81903
+    # endregion
+    # region monk
+    (9224, 502, 1, 246, "Wanderer's Insignia"),  # 240801F6
+    (9224, 503, 1, 247, "Disciple's Insignia"),  # 240801F7
+    (9224, 504, 1, 248, "Anchorite's Insignia"),  # 240801F8
+    (8680, 3329, 13, 1, "Rune of Minor Healing Prayers"),  # 21E80D01
+    (8680, 3585, 14, 1, "Rune of Minor Smiting Prayers"),  # 21E80E01
+    (8680, 3841, 15, 1, "Rune of Minor Protection Prayers"),  # 21E80F01
+    (8680, 4097, 16, 1, "Rune of Minor Divine Favor"),  # 21E81001
+    (8680, 3330, 13, 2, "Rune of Major Healing Prayers"),  # 21E80D02
+    (8680, 3586, 14, 2, "Rune of Major Smiting Prayers"),  # 21E80E02
+    (8680, 3842, 15, 2, "Rune of Major Protection Prayers"),  # 21E80F02
+    (8680, 4098, 16, 2, "Rune of Major Divine Favor"),  # 21E81002
+    (8680, 3331, 13, 3, "Rune of Superior Healing Prayers"),  # 21E80D03
+    (8680, 3587, 14, 3, "Rune of Superior Smiting Prayers"),  # 21E80E03
+    (8680, 3843, 15, 3, "Rune of Superior Protection Prayers"),  # 21E80F03
+    (8680, 4099, 16, 3, "Rune of Superior Divine Favor"),  # 21E81003
+    # endregion
+    # region necromancer
+    (9224, 522, 2, 10, "Bloodstained Insignia"),  # 2408020A
+    (9224, 492, 1, 236, "Tormentor's Insignia"),  # 240801EC
+    (9224, 494, 1, 238, "Bonelace Insignia"),  # 240801EE
+    (9224, 495, 1, 239, "Minion Master's Insignia"),  # 240801EF
+    (9224, 496, 1, 240, "Blighter's Insignia"),  # 240801F0
+    (9224, 493, 1, 237, "Undertaker's Insignia"),  # 240801ED
+    (8680, 1025, 4, 1, "Rune of Minor Blood Magic"),  # 21E80401
+    (8680, 1281, 5, 1, "Rune of Minor Death Magic"),  # 21E80501
+    (8680, 1793, 7, 1, "Rune of Minor Curses"),  # 21E80701
+    (8680, 1537, 6, 1, "Rune of Minor Soul Reaping"),  # 21E80601
+    (8680, 1026, 4, 2, "Rune of Major Blood Magic"),  # 21E80402
+    (8680, 1282, 5, 2, "Rune of Major Death Magic"),  # 21E80502
+    (8680, 1794, 7, 2, "Rune of Major Curses"),  # 21E80702
+    (8680, 1538, 6, 2, "Rune of Major Soul Reaping"),  # 21E80602
+    (8680, 1027, 4, 3, "Rune of Superior Blood Magic"),  # 21E80403
+    (8680, 1283, 5, 3, "Rune of Superior Death Magic"),  # 21E80503
+    (8680, 1795, 7, 3, "Rune of Superior Curses"),  # 21E80703
+    (8680, 1539, 6, 3, "Rune of Superior Soul Reaping"),  # 21E80603
+    # endregion
+    # region mesmer
+    (9224, 484, 1, 228, "Virtuoso's Insignia"),  # 240801E4
+    (9224, 482, 1, 226, "Artificer's Insignia"),  # 240801E2
+    (9224, 483, 1, 227, "Prodigy's Insignia"),  # 240801E3
+    (8680, 1, 0, 1, "Rune of Minor Fast Casting"),  # 21E80001
+    (8680, 513, 2, 1, "Rune of Minor Domination Magic"),  # 21E80201
+    (8680, 257, 1, 1, "Rune of Minor Illusion Magic"),  # 21E80101
+    (8680, 769, 3, 1, "Rune of Minor Inspiration Magic"),  # 21E80301
+    (8680, 2, 0, 2, "Rune of Major Fast Casting"),  # 21E80002
+    (8680, 514, 2, 2, "Rune of Major Domination Magic"),  # 21E80202
+    (8680, 258, 1, 2, "Rune of Major Illusion Magic"),  # 21E80102
+    (8680, 770, 3, 2, "Rune of Major Inspiration Magic"),  # 21E80302
+    (8680, 3, 0, 3, "Rune of Superior Fast Casting"),  # 21E80003
+    (8680, 515, 2, 3, "Rune of Superior Domination Magic"),  # 21E80203
+    (8680, 259, 1, 3, "Rune of Superior Illusion Magic"),  # 21E80103
+    (8680, 771, 3, 3, "Rune of Superior Inspiration Magic"),  # 21E80303
+    # endregion
+    # region elementalist
+    (9224, 498, 1, 242, "Hydromancer Insignia"),  # 240801F2
+    (9224, 499, 1, 243, "Geomancer Insignia"),  # 240801F3
+    (9224, 500, 1, 244, "Pyromancer Insignia"),  # 240801F4
+    (9224, 501, 1, 245, "Aeromancer Insignia"),  # 240801F5
+    (9224, 497, 1, 241, "Prismatic Insignia"),  # 240801F1
+    (8680, 3073, 12, 1, "Rune of Minor Energy Storage"),  # 21E80C01
+    (8680, 2561, 10, 1, "Rune of Minor Fire Magic"),  # 21E80A01
+    (8680, 2049, 8, 1, "Rune of Minor Air Magic"),  # 21E80801
+    (8680, 2305, 9, 1, "Rune of Minor Earth Magic"),  # 21E80901
+    (8680, 2817, 11, 1, "Rune of Minor Water Magic"),  # 21E80B01
+    (8680, 3074, 12, 2, "Rune of Major Energy Storage"),  # 21E80C02
+    (8680, 2562, 10, 2, "Rune of Major Fire Magic"),  # 21E80A02
+    (8680, 2050, 8, 2, "Rune of Major Air Magic"),  # 21E80802
+    (8680, 2306, 9, 2, "Rune of Major Earth Magic"),  # 21E80902
+    (8680, 2818, 11, 2, "Rune of Major Water Magic"),  # 21E80B02
+    (8680, 3075, 12, 3, "Rune of Superior Energy Storage"),  # 21E80C03
+    (8680, 2563, 10, 3, "Rune of Superior Fire Magic"),  # 21E80A03
+    (8680, 2051, 8, 3, "Rune of Superior Air Magic"),  # 21E80803
+    (8680, 2307, 9, 3, "Rune of Superior Earth Magic"),  # 21E80903
+    (8680, 2819, 11, 3, "Rune of Superior Water Magic"),  # 21E80B03
+    # endregion
+    # region assassin
+    (9224, 478, 1, 222, "Vanguard's Insignia"),  # 240801DE
+    (9224, 479, 1, 223, "Infiltrator's Insignia"),  # 240801DF
+    (9224, 480, 1, 224, "Saboteur's Insignia"),  # 240801E0
+    (9224, 481, 1, 225, "Nightstalker's Insignia"),  # 240801E1
+    (8680, 8961, 35, 1, "Rune of Minor Critical Strikes"),  # 21E82301
+    (8680, 7425, 29, 1, "Rune of Minor Dagger Mastery"),  # 21E81D01
+    (8680, 7681, 30, 1, "Rune of Minor Deadly Arts"),  # 21E81E01
+    (8680, 7937, 31, 1, "Rune of Minor Shadow Arts"),  # 21E81F01
+    (8680, 8962, 35, 2, "Rune of Major Critical Strikes"),  # 21E82302
+    (8680, 7426, 29, 2, "Rune of Major Dagger Mastery"),  # 21E81D02
+    (8680, 7682, 30, 2, "Rune of Major Deadly Arts"),  # 21E81E02
+    (8680, 7938, 31, 2, "Rune of Major Shadow Arts"),  # 21E81F02
+    (8680, 8963, 35, 3, "Rune of Superior Critical Strikes"),  # 21E82303
+    (8680, 7427, 29, 3, "Rune of Superior Dagger Mastery"),  # 21E81D03
+    (8680, 7683, 30, 3, "Rune of Superior Deadly Arts"),  # 21E81E03
+    (8680, 7939, 31, 3, "Rune of Superior Shadow Arts"),  # 21E81F03
+    # endregion
+    # region ritualist
+    (9224, 516, 2, 4, "Shaman's Insignia"),  # 24080204
+    (9224, 517, 2, 5, "Ghost Forge Insignia"),  # 24080205
+    (9224, 518, 2, 6, "Mystic's Insignia"),  # 24080206
+    (8680, 8705, 34, 1, "Rune of Minor Channeling Magic"),  # 21E82201
+    (8680, 8449, 33, 1, "Rune of Minor Restoration Magic"),  # 21E82101
+    (8680, 8193, 32, 1, "Rune of Minor Communing"),  # 21E82001
+    (8680, 9217, 36, 1, "Rune of Minor Spawning Power"),  # 21E82401
+    (8680, 8706, 34, 2, "Rune of Major Channeling Magic"),  # 21E82202
+    (8680, 8450, 33, 2, "Rune of Major Restoration Magic"),  # 21E82102
+    (8680, 8194, 32, 2, "Rune of Major Communing"),  # 21E82002
+    (8680, 9218, 36, 2, "Rune of Major Spawning Power"),  # 21E82402
+    (8680, 8707, 34, 3, "Rune of Superior Channeling Magic"),  # 21E82203
+    (8680, 8451, 33, 3, "Rune of Superior Restoration Magic"),  # 21E82103
+    (8680, 8195, 32, 3, "Rune of Superior Communing"),  # 21E82003
+    (8680, 9219, 36, 3, "Rune of Superior Spawning Power"),  # 21E82403
+    # endregion
+    # region dervish
+    (9224, 514, 2, 2, "Windwalker Insignia"),  # 24080202
+    (9224, 515, 2, 3, "Forsaken Insignia"),  # 24080203
+    (8680, 11265, 44, 1, "Rune of Minor Mysticism"),  # 21E82C01
+    (8680, 11009, 43, 1, "Rune of Minor Earth Prayers"),  # 21E82B01
+    (8680, 10497, 41, 1, "Rune of Minor Scythe Mastery"),  # 21E82901
+    (8680, 10753, 42, 1, "Rune of Minor Wind Prayers"),  # 21E82A01
+    (8680, 11266, 44, 2, "Rune of Major Mysticism"),  # 21E82C02
+    (8680, 11010, 43, 2, "Rune of Major Earth Prayers"),  # 21E82B02
+    (8680, 10498, 41, 2, "Rune of Major Scythe Mastery"),  # 21E82902
+    (8680, 10754, 42, 2, "Rune of Major Wind Prayers"),  # 21E82A02
+    (8680, 11267, 44, 3, "Rune of Superior Mysticism"),  # 21E82C03
+    (8680, 11011, 43, 3, "Rune of Superior Earth Prayers"),  # 21E82B03
+    (8680, 10499, 41, 3, "Rune of Superior Scythe Mastery"),  # 21E82903
+    (8680, 10755, 42, 3, "Rune of Superior Wind Prayers"),  # 21E82A03
+    # endregion
+    # region paragon
+    (9224, 519, 2, 7, "Centurion's Insignia"),  # 24080207
+    (8680, 10241, 40, 1, "Rune of Minor Leadership"),  # 21E82801
+    (8680, 9985, 39, 1, "Rune of Minor Motivation"),  # 21E82701
+    (8680, 9729, 38, 1, "Rune of Minor Command"),  # 21E82601
+    (8680, 9473, 37, 1, "Rune of Minor Spear Mastery"),  # 21E82501
+    (8680, 10242, 40, 2, "Rune of Major Leadership"),  # 21E82802
+    (8680, 9986, 39, 2, "Rune of Major Motivation"),  # 21E82702
+    (8680, 9730, 38, 2, "Rune of Major Command"),  # 21E82602
+    (8680, 9474, 37, 2, "Rune of Major Spear Mastery"),  # 21E82502
+    (8680, 10243, 40, 3, "Rune of Superior Leadership"),  # 21E82803
+    (8680, 9987, 39, 3, "Rune of Superior Motivation"),  # 21E82703
+    (8680, 9731, 38, 3, "Rune of Superior Command"),  # 21E82603
+    (8680, 9475, 37, 3, "Rune of Superior Spear Mastery"),  # 21E82503
+    # endregion
+    # region common
+    (9224, 486, 1, 230, "Survivor Insignia"),  # 240801E6
+    (9224, 485, 1, 229, "Radiant Insignia"),  # 240801E5
+    (9224, 487, 1, 231, "Stalwart Insignia"),  # 240801E7
+    (9224, 488, 1, 232, "Brawler's Insignia"),  # 240801E8
+    (9224, 489, 1, 233, "Blessed Insignia"),  # 240801E9
+    (9224, 490, 1, 234, "Herald's Insignia"),  # 240801EA
+    (9224, 491, 1, 235, "Sentry's Insignia"),  # 240801EB
+    (9224, 529, 2, 17, "Rune of Attunement"),  # 24080211
+    (9224, 531, 2, 19, "Rune of Recovery"),  # 24080213
+    (9224, 532, 2, 20, "Rune of Restoration"),  # 24080214
+    (9224, 533, 2, 21, "Rune of Clarity"),  # 24080215
+    (9224, 534, 2, 22, "Rune of Purity"),  # 24080216
+    (9224, 255, 0, 255, "Rune of Minor Vigor"),  # 240800FF
+    (9224, 194, 0, 194, "Rune of Minor Vigor"),  # 240800C2
+    (9224, 257, 1, 1, "Rune of Superior Vigor"),  # 24080101
+    (9224, 256, 1, 0, "Rune of Major Vigor"),  # 24080100
+    (9224, 530, 2, 18, "Rune of Vitae"),  # 24080212
+    # endregion
 ]
 
 

--- a/Legacy code and tests/ItemCompare.py
+++ b/Legacy code and tests/ItemCompare.py
@@ -40,233 +40,209 @@ def add_modifier(modifier):
     modifiers[next_key] = modifier
 
 
-ARMOR_MODIFIERS_HEX_DATA = {
-    # region warrior
-    "240801F9": "Knight's Insignia",
-    "24080208": "Lieutenant's Insignia",
-    "24080209": "Stonefist Insignia",
-    "240801FA": "Dreadnought Insignia",
-    "240801FB": "Sentinel's Insignia",
-    "240800FC": "Rune of Minor Absorption",
-    "21E81501": "Rune of Minor Tactics",
-    "21E81101": "Rune of Minor Strength",
-    "21E81201": "Rune of Minor Axe Mastery",
-    "21E81301": "Rune of Minor Hammer Mastery",
-    "21E81401": "Rune of Minor Swordsmanship",
-    "240800FD": "Rune of Major Absorption",
-    "21E81502": "Rune of Major Tactics",
-    "21E81102": "Rune of Major Strength",
-    "21E81202": "Rune of Major Axe Mastery",
-    "21E81302": "Rune of Major Hammer Mastery",
-    "21E81402": "Rune of Major Swordsmanship",
-    "240800FE": "Rune of Superior Absorption",
-    "21E81503": "Rune of Superior Tactics",
-    "21E81103": "Rune of Superior Strength",
-    "21E81203": "Rune of Superior Axe Mastery",
-    "21E81303": "Rune of Superior Hammer Mastery",
-    "21E81403": "Rune of Superior Swordsmanship",
-    # endregion
-    # region ranger
-    "240801FC": "Frostbound Insignia",
-    "240801FE": "Pyrebound Insignia",
-    "240801FF": "Stormbound Insignia",
-    "24080201": "Scout's Insignia",
-    "240801FD": "Earthbound Insignia",
-    "24080200": "Beastmaster's Insignia",
-    "21E81801": "Rune of Minor Wilderness Survival",
-    "21E81701": "Rune of Minor Expertise",
-    "21E81601": "Rune of Minor Beast Mastery",
-    "21E81901": "Rune of Minor Marksmanship",
-    "21E81802": "Rune of Major Wilderness Survival",
-    "21E81702": "Rune of Major Expertise",
-    "21E81602": "Rune of Major Beast Mastery",
-    "21E81902": "Rune of Major Marksmanship",
-    "21E81803": "Rune of Superior Wilderness Survival",
-    "21E81703": "Rune of Superior Expertise",
-    "21E81603": "Rune of Superior Beast Mastery",
-    "21E81903": "Rune of Superior Marksmanship",
-    # endregion
-    # region monk
-    "240801F6": "Wanderer's Insignia",
-    "240801F7": "Disciple's Insignia",
-    "240801F8": "Anchorite's Insignia",
-    "21E80D01": "Rune of Minor Healing Prayers",
-    "21E80E01": "Rune of Minor Smiting Prayers",
-    "21E80F01": "Rune of Minor Protection Prayers",
-    "21E81001": "Rune of Minor Divine Favor",
-    "21E80D02": "Rune of Major Healing Prayers",
-    "21E80E02": "Rune of Major Smiting Prayers",
-    "21E80F02": "Rune of Major Protection Prayers",
-    "21E81002": "Rune of Major Divine Favor",
-    "21E80D03": "Rune of Superior Healing Prayers",
-    "21E80E03": "Rune of Superior Smiting Prayers",
-    "21E80F03": "Rune of Superior Protection Prayers",
-    "21E81003": "Rune of Superior Divine Favor",
-    # endregion
-    # region necromancer
-    "2408020A": "Bloodstained Insignia",
-    "240801EC": "Tormentor's Insignia",
-    "240801EE": "Bonelace Insignia",
-    "240801EF": "Minion Master's Insignia",
-    "240801F0": "Blighter's Insignia",
-    "240801ED": "Undertaker's Insignia",
-    "21E80401": "Rune of Minor Blood Magic",
-    "21E80501": "Rune of Minor Death Magic",
-    "21E80701": "Rune of Minor Curses",
-    "21E80601": "Rune of Minor Soul Reaping",
-    "21E80402": "Rune of Major Blood Magic",
-    "21E80502": "Rune of Major Death Magic",
-    "21E80702": "Rune of Major Curses",
-    "21E80602": "Rune of Major Soul Reaping",
-    "21E80403": "Rune of Superior Blood Magic",
-    "21E80503": "Rune of Superior Death Magic",
-    "21E80703": "Rune of Superior Curses",
-    "21E80603": "Rune of Superior Soul Reaping",
-    # endregion
-    # region mesmer
-    "240801E4": "Virtuoso's Insignia",
-    "240801E2": "Artificer's Insignia",
-    "240801E3": "Prodigy's Insignia",
-    "21E80001": "Rune of Minor Fast Casting",
-    "21E80201": "Rune of Minor Domination Magic",
-    "21E80101": "Rune of Minor Illusion Magic",
-    "21E80301": "Rune of Minor Inspiration Magic",
-    "21E80002": "Rune of Major Fast Casting",
-    "21E80202": "Rune of Major Domination Magic",
-    "21E80102": "Rune of Major Illusion Magic",
-    "21E80302": "Rune of Major Inspiration Magic",
-    "21E80003": "Rune of Superior Fast Casting",
-    "21E80203": "Rune of Superior Domination Magic",
-    "21E80103": "Rune of Superior Illusion Magic",
-    "21E80303": "Rune of Superior Inspiration Magic",
-    # endregion
-    # region elementalist
-    "240801F2": "Hydromancer Insignia",
-    "240801F3": "Geomancer Insignia",
-    "240801F4": "Pyromancer Insignia",
-    "240801F5": "Aeromancer Insignia",
-    "240801F1": "Prismatic Insignia",
-    "21E80C01": "Rune of Minor Energy Storage",
-    "21E80A01": "Rune of Minor Fire Magic",
-    "21E80801": "Rune of Minor Air Magic",
-    "21E80901": "Rune of Minor Earth Magic",
-    "21E80B01": "Rune of Minor Water Magic",
-    "21E80C02": "Rune of Major Energy Storage",
-    "21E80A02": "Rune of Major Fire Magic",
-    "21E80802": "Rune of Major Air Magic",
-    "21E80902": "Rune of Major Earth Magic",
-    "21E80B02": "Rune of Major Water Magic",
-    "21E80C03": "Rune of Superior Energy Storage",
-    "21E80A03": "Rune of Superior Fire Magic",
-    "21E80803": "Rune of Superior Air Magic",
-    "21E80903": "Rune of Superior Earth Magic",
-    "21E80B03": "Rune of Superior Water Magic",
-    # endregion
-    # region assassin
-    "240801DE": "Vanguard's Insignia",
-    "240801DF": "Infiltrator's Insignia",
-    "240801E0": "Saboteur's Insignia",
-    "240801E1": "Nightstalker's Insignia",
-    "21E82301": "Rune of Minor Critical Strikes",
-    "21E81D01": "Rune of Minor Dagger Mastery",
-    "21E81E01": "Rune of Minor Deadly Arts",
-    "21E81F01": "Rune of Minor Shadow Arts",
-    "21E82302": "Rune of Major Critical Strikes",
-    "21E81D02": "Rune of Major Dagger Mastery",
-    "21E81E02": "Rune of Major Deadly Arts",
-    "21E81F02": "Rune of Major Shadow Arts",
-    "21E82303": "Rune of Superior Critical Strikes",
-    "21E81D03": "Rune of Superior Dagger Mastery",
-    "21E81E03": "Rune of Superior Deadly Arts",
-    "21E81F03": "Rune of Superior Shadow Arts",
-    # endregion
-    # region ritualist
-    "24080204": "Shaman's Insignia",
-    "24080205": "Ghost Forge Insignia",
-    "24080206": "Mystic's Insignia",
-    "21E82201": "Rune of Minor Channeling Magic",
-    "21E82101": "Rune of Minor Restoration Magic",
-    "21E82001": "Rune of Minor Communing",
-    "21E82401": "Rune of Minor Spawning Power",
-    "21E82202": "Rune of Major Channeling Magic",
-    "21E82102": "Rune of Major Restoration Magic",
-    "21E82002": "Rune of Major Communing",
-    "21E82402": "Rune of Major Spawning Power",
-    "21E82203": "Rune of Superior Channeling Magic",
-    "21E82103": "Rune of Superior Restoration Magic",
-    "21E82003": "Rune of Superior Communing",
-    "21E82403": "Rune of Superior Spawning Power",
-    # endregion
-    # region dervish
-    "24080202": "Windwalker Insignia",
-    "24080203": "Forsaken Insignia",
-    "21E82C01": "Rune of Minor Mysticism",
-    "21E82B01": "Rune of Minor Earth Prayers",
-    "21E82901": "Rune of Minor Scythe Mastery",
-    "21E82A01": "Rune of Minor Wind Prayers",
-    "21E82C02": "Rune of Major Mysticism",
-    "21E82B02": "Rune of Major Earth Prayers",
-    "21E82902": "Rune of Major Scythe Mastery",
-    "21E82A02": "Rune of Major Wind Prayers",
-    "21E82C03": "Rune of Superior Mysticism",
-    "21E82B03": "Rune of Superior Earth Prayers",
-    "21E82903": "Rune of Superior Scythe Mastery",
-    "21E82A03": "Rune of Superior Wind Prayers",
-    # endregion
-    # region paragon
-    "24080207": "Centurion's Insignia",
-    "21E82801": "Rune of Minor Leadership",
-    "21E82701": "Rune of Minor Motivation",
-    "21E82601": "Rune of Minor Command",
-    "21E82501": "Rune of Minor Spear Mastery",
-    "21E82802": "Rune of Major Leadership",
-    "21E82702": "Rune of Major Motivation",
-    "21E82602": "Rune of Major Command",
-    "21E82502": "Rune of Major Spear Mastery",
-    "21E82803": "Rune of Superior Leadership",
-    "21E82703": "Rune of Superior Motivation",
-    "21E82603": "Rune of Superior Command",
-    "21E82503": "Rune of Superior Spear Mastery",
-    # endregion
-    # region common
-    "240801E6": "Survivor Insignia",
-    "240801E5": "Radiant Insignia",
-    "240801E7": "Stalwart Insignia",
-    "240801E8": "Brawler's Insignia",
-    "240801E9": "Blessed Insignia",
-    "240801EA": "Herald's Insignia",
-    "240801EB": "Sentry's Insignia",
-    "24080211": "Rune of Attunement",
-    "24080213": "Rune of Recovery",
-    "24080214": "Rune of Restoration",
-    "24080215": "Rune of Clarity",
-    "24080216": "Rune of Purity",
-    "240800FF": "Rune of Minor Vigor",
-    "240800C2": "Rune of Minor Vigor",
-    "24080101": "Rune of Superior Vigor",
-    "24080100": "Rune of Major Vigor",
-    "24080212": "Rune of Vitae",
-}
+ARMOR_MODIFIERS_HEX_DATA = [
+    (0x21E8, 0x0001, 0x0000, 0x0000, "Rune of Minor Fast Casting"),  # 21E80001
+    (0x21E8, 0x0002, 0x0000, 0x0000, "Rune of Major Fast Casting"),  # 21E80002
+    (0x21E8, 0x0003, 0x0000, 0x0000, "Rune of Superior Fast Casting"),  # 21E80003
+    (0x21E8, 0x0101, 0x0000, 0x0000, "Rune of Minor Illusion Magic"),  # 21E80101
+    (0x21E8, 0x0102, 0x0000, 0x0000, "Rune of Major Illusion Magic"),  # 21E80102
+    (0x21E8, 0x0103, 0x0000, 0x0000, "Rune of Superior Illusion Magic"),  # 21E80103
+    (0x21E8, 0x0201, 0x0000, 0x0000, "Rune of Minor Domination Magic"),  # 21E80201
+    (0x21E8, 0x0202, 0x0000, 0x0000, "Rune of Major Domination Magic"),  # 21E80202
+    (0x21E8, 0x0203, 0x0000, 0x0000, "Rune of Superior Domination Magic"),  # 21E80203
+    (0x21E8, 0x0301, 0x0000, 0x0000, "Rune of Minor Inspiration Magic"),  # 21E80301
+    (0x21E8, 0x0302, 0x0000, 0x0000, "Rune of Major Inspiration Magic"),  # 21E80302
+    (0x21E8, 0x0303, 0x0000, 0x0000, "Rune of Superior Inspiration Magic"),  # 21E80303
+    (0x21E8, 0x0401, 0x0000, 0x0000, "Rune of Minor Blood Magic"),  # 21E80401
+    (0x21E8, 0x0402, 0x0000, 0x0000, "Rune of Major Blood Magic"),  # 21E80402
+    (0x21E8, 0x0403, 0x0000, 0x0000, "Rune of Superior Blood Magic"),  # 21E80403
+    (0x21E8, 0x0501, 0x0000, 0x0000, "Rune of Minor Death Magic"),  # 21E80501
+    (0x21E8, 0x0502, 0x0000, 0x0000, "Rune of Major Death Magic"),  # 21E80502
+    (0x21E8, 0x0503, 0x0000, 0x0000, "Rune of Superior Death Magic"),  # 21E80503
+    (0x21E8, 0x0601, 0x0000, 0x0000, "Rune of Minor Soul Reaping"),  # 21E80601
+    (0x21E8, 0x0602, 0x0000, 0x0000, "Rune of Major Soul Reaping"),  # 21E80602
+    (0x21E8, 0x0603, 0x0000, 0x0000, "Rune of Superior Soul Reaping"),  # 21E80603
+    (0x21E8, 0x0701, 0x0000, 0x0000, "Rune of Minor Curses"),  # 21E80701
+    (0x21E8, 0x0702, 0x0000, 0x0000, "Rune of Major Curses"),  # 21E80702
+    (0x21E8, 0x0703, 0x0000, 0x0000, "Rune of Superior Curses"),  # 21E80703
+    (0x21E8, 0x0801, 0x0000, 0x0000, "Rune of Minor Air Magic"),  # 21E80801
+    (0x21E8, 0x0802, 0x0000, 0x0000, "Rune of Major Air Magic"),  # 21E80802
+    (0x21E8, 0x0803, 0x0000, 0x0000, "Rune of Superior Air Magic"),  # 21E80803
+    (0x21E8, 0x0901, 0x0000, 0x0000, "Rune of Minor Earth Magic"),  # 21E80901
+    (0x21E8, 0x0902, 0x0000, 0x0000, "Rune of Major Earth Magic"),  # 21E80902
+    (0x21E8, 0x0903, 0x0000, 0x0000, "Rune of Superior Earth Magic"),  # 21E80903
+    (0x21E8, 0x0A01, 0x0000, 0x0000, "Rune of Minor Fire Magic"),  # 21E80A01
+    (0x21E8, 0x0A02, 0x0000, 0x0000, "Rune of Major Fire Magic"),  # 21E80A02
+    (0x21E8, 0x0A03, 0x0000, 0x0000, "Rune of Superior Fire Magic"),  # 21E80A03
+    (0x21E8, 0x0B01, 0x0000, 0x0000, "Rune of Minor Water Magic"),  # 21E80B01
+    (0x21E8, 0x0B02, 0x0000, 0x0000, "Rune of Major Water Magic"),  # 21E80B02
+    (0x21E8, 0x0B03, 0x0000, 0x0000, "Rune of Superior Water Magic"),  # 21E80B03
+    (0x21E8, 0x0C01, 0x0000, 0x0000, "Rune of Minor Energy Storage"),  # 21E80C01
+    (0x21E8, 0x0C02, 0x0000, 0x0000, "Rune of Major Energy Storage"),  # 21E80C02
+    (0x21E8, 0x0C03, 0x0000, 0x0000, "Rune of Superior Energy Storage"),  # 21E80C03
+    (0x21E8, 0x0D01, 0x0000, 0x0000, "Rune of Minor Healing Prayers"),  # 21E80D01
+    (0x21E8, 0x0D02, 0x0000, 0x0000, "Rune of Major Healing Prayers"),  # 21E80D02
+    (0x21E8, 0x0D03, 0x0000, 0x0000, "Rune of Superior Healing Prayers"),  # 21E80D03
+    (0x21E8, 0x0E01, 0x0000, 0x0000, "Rune of Minor Smiting Prayers"),  # 21E80E01
+    (0x21E8, 0x0E02, 0x0000, 0x0000, "Rune of Major Smiting Prayers"),  # 21E80E02
+    (0x21E8, 0x0E03, 0x0000, 0x0000, "Rune of Superior Smiting Prayers"),  # 21E80E03
+    (0x21E8, 0x0F01, 0x0000, 0x0000, "Rune of Minor Protection Prayers"),  # 21E80F01
+    (0x21E8, 0x0F02, 0x0000, 0x0000, "Rune of Major Protection Prayers"),  # 21E80F02
+    (0x21E8, 0x0F03, 0x0000, 0x0000, "Rune of Superior Protection Prayers"),  # 21E80F03
+    (0x21E8, 0x1001, 0x0000, 0x0000, "Rune of Minor Divine Favor"),  # 21E81001
+    (0x21E8, 0x1002, 0x0000, 0x0000, "Rune of Major Divine Favor"),  # 21E81002
+    (0x21E8, 0x1003, 0x0000, 0x0000, "Rune of Superior Divine Favor"),  # 21E81003
+    (0x21E8, 0x1101, 0x0000, 0x0000, "Rune of Minor Strength"),  # 21E81101
+    (0x21E8, 0x1102, 0x0000, 0x0000, "Rune of Major Strength"),  # 21E81102
+    (0x21E8, 0x1103, 0x0000, 0x0000, "Rune of Superior Strength"),  # 21E81103
+    (0x21E8, 0x1201, 0x0000, 0x0000, "Rune of Minor Axe Mastery"),  # 21E81201
+    (0x21E8, 0x1202, 0x0000, 0x0000, "Rune of Major Axe Mastery"),  # 21E81202
+    (0x21E8, 0x1203, 0x0000, 0x0000, "Rune of Superior Axe Mastery"),  # 21E81203
+    (0x21E8, 0x1301, 0x0000, 0x0000, "Rune of Minor Hammer Mastery"),  # 21E81301
+    (0x21E8, 0x1302, 0x0000, 0x0000, "Rune of Major Hammer Mastery"),  # 21E81302
+    (0x21E8, 0x1303, 0x0000, 0x0000, "Rune of Superior Hammer Mastery"),  # 21E81303
+    (0x21E8, 0x1401, 0x0000, 0x0000, "Rune of Minor Swordsmanship"),  # 21E81401
+    (0x21E8, 0x1402, 0x0000, 0x0000, "Rune of Major Swordsmanship"),  # 21E81402
+    (0x21E8, 0x1403, 0x0000, 0x0000, "Rune of Superior Swordsmanship"),  # 21E81403
+    (0x21E8, 0x1501, 0x0000, 0x0000, "Rune of Minor Tactics"),  # 21E81501
+    (0x21E8, 0x1502, 0x0000, 0x0000, "Rune of Major Tactics"),  # 21E81502
+    (0x21E8, 0x1503, 0x0000, 0x0000, "Rune of Superior Tactics"),  # 21E81503
+    (0x21E8, 0x1601, 0x0000, 0x0000, "Rune of Minor Beast Mastery"),  # 21E81601
+    (0x21E8, 0x1602, 0x0000, 0x0000, "Rune of Major Beast Mastery"),  # 21E81602
+    (0x21E8, 0x1603, 0x0000, 0x0000, "Rune of Superior Beast Mastery"),  # 21E81603
+    (0x21E8, 0x1701, 0x0000, 0x0000, "Rune of Minor Expertise"),  # 21E81701
+    (0x21E8, 0x1702, 0x0000, 0x0000, "Rune of Major Expertise"),  # 21E81702
+    (0x21E8, 0x1703, 0x0000, 0x0000, "Rune of Superior Expertise"),  # 21E81703
+    (0x21E8, 0x1801, 0x0000, 0x0000, "Rune of Minor Wilderness Survival"),  # 21E81801
+    (0x21E8, 0x1802, 0x0000, 0x0000, "Rune of Major Wilderness Survival"),  # 21E81802
+    (0x21E8, 0x1803, 0x0000, 0x0000, "Rune of Superior Wilderness Survival"),  # 21E81803
+    (0x21E8, 0x1901, 0x0000, 0x0000, "Rune of Minor Marksmanship"),  # 21E81901
+    (0x21E8, 0x1902, 0x0000, 0x0000, "Rune of Major Marksmanship"),  # 21E81902
+    (0x21E8, 0x1903, 0x0000, 0x0000, "Rune of Superior Marksmanship"),  # 21E81903
+    (0x21E8, 0x1D01, 0x0000, 0x0000, "Rune of Minor Dagger Mastery"),  # 21E81D01
+    (0x21E8, 0x1D02, 0x0000, 0x0000, "Rune of Major Dagger Mastery"),  # 21E81D02
+    (0x21E8, 0x1D03, 0x0000, 0x0000, "Rune of Superior Dagger Mastery"),  # 21E81D03
+    (0x21E8, 0x1E01, 0x0000, 0x0000, "Rune of Minor Deadly Arts"),  # 21E81E01
+    (0x21E8, 0x1E02, 0x0000, 0x0000, "Rune of Major Deadly Arts"),  # 21E81E02
+    (0x21E8, 0x1E03, 0x0000, 0x0000, "Rune of Superior Deadly Arts"),  # 21E81E03
+    (0x21E8, 0x1F01, 0x0000, 0x0000, "Rune of Minor Shadow Arts"),  # 21E81F01
+    (0x21E8, 0x1F02, 0x0000, 0x0000, "Rune of Major Shadow Arts"),  # 21E81F02
+    (0x21E8, 0x1F03, 0x0000, 0x0000, "Rune of Superior Shadow Arts"),  # 21E81F03
+    (0x21E8, 0x2001, 0x0000, 0x0000, "Rune of Minor Communing"),  # 21E82001
+    (0x21E8, 0x2002, 0x0000, 0x0000, "Rune of Major Communing"),  # 21E82002
+    (0x21E8, 0x2003, 0x0000, 0x0000, "Rune of Superior Communing"),  # 21E82003
+    (0x21E8, 0x2101, 0x0000, 0x0000, "Rune of Minor Restoration Magic"),  # 21E82101
+    (0x21E8, 0x2102, 0x0000, 0x0000, "Rune of Major Restoration Magic"),  # 21E82102
+    (0x21E8, 0x2103, 0x0000, 0x0000, "Rune of Superior Restoration Magic"),  # 21E82103
+    (0x21E8, 0x2201, 0x0000, 0x0000, "Rune of Minor Channeling Magic"),  # 21E82201
+    (0x21E8, 0x2202, 0x0000, 0x0000, "Rune of Major Channeling Magic"),  # 21E82202
+    (0x21E8, 0x2203, 0x0000, 0x0000, "Rune of Superior Channeling Magic"),  # 21E82203
+    (0x21E8, 0x2301, 0x0000, 0x0000, "Rune of Minor Critical Strikes"),  # 21E82301
+    (0x21E8, 0x2302, 0x0000, 0x0000, "Rune of Major Critical Strikes"),  # 21E82302
+    (0x21E8, 0x2303, 0x0000, 0x0000, "Rune of Superior Critical Strikes"),  # 21E82303
+    (0x21E8, 0x2401, 0x0000, 0x0000, "Rune of Minor Spawning Power"),  # 21E82401
+    (0x21E8, 0x2402, 0x0000, 0x0000, "Rune of Major Spawning Power"),  # 21E82402
+    (0x21E8, 0x2403, 0x0000, 0x0000, "Rune of Superior Spawning Power"),  # 21E82403
+    (0x21E8, 0x2501, 0x0000, 0x0000, "Rune of Minor Spear Mastery"),  # 21E82501
+    (0x21E8, 0x2502, 0x0000, 0x0000, "Rune of Major Spear Mastery"),  # 21E82502
+    (0x21E8, 0x2503, 0x0000, 0x0000, "Rune of Superior Spear Mastery"),  # 21E82503
+    (0x21E8, 0x2601, 0x0000, 0x0000, "Rune of Minor Command"),  # 21E82601
+    (0x21E8, 0x2602, 0x0000, 0x0000, "Rune of Major Command"),  # 21E82602
+    (0x21E8, 0x2603, 0x0000, 0x0000, "Rune of Superior Command"),  # 21E82603
+    (0x21E8, 0x2701, 0x0000, 0x0000, "Rune of Minor Motivation"),  # 21E82701
+    (0x21E8, 0x2702, 0x0000, 0x0000, "Rune of Major Motivation"),  # 21E82702
+    (0x21E8, 0x2703, 0x0000, 0x0000, "Rune of Superior Motivation"),  # 21E82703
+    (0x21E8, 0x2801, 0x0000, 0x0000, "Rune of Minor Leadership"),  # 21E82801
+    (0x21E8, 0x2802, 0x0000, 0x0000, "Rune of Major Leadership"),  # 21E82802
+    (0x21E8, 0x2803, 0x0000, 0x0000, "Rune of Superior Leadership"),  # 21E82803
+    (0x21E8, 0x2901, 0x0000, 0x0000, "Rune of Minor Scythe Mastery"),  # 21E82901
+    (0x21E8, 0x2902, 0x0000, 0x0000, "Rune of Major Scythe Mastery"),  # 21E82902
+    (0x21E8, 0x2903, 0x0000, 0x0000, "Rune of Superior Scythe Mastery"),  # 21E82903
+    (0x21E8, 0x2A01, 0x0000, 0x0000, "Rune of Minor Wind Prayers"),  # 21E82A01
+    (0x21E8, 0x2A02, 0x0000, 0x0000, "Rune of Major Wind Prayers"),  # 21E82A02
+    (0x21E8, 0x2A03, 0x0000, 0x0000, "Rune of Superior Wind Prayers"),  # 21E82A03
+    (0x21E8, 0x2B01, 0x0000, 0x0000, "Rune of Minor Earth Prayers"),  # 21E82B01
+    (0x21E8, 0x2B02, 0x0000, 0x0000, "Rune of Major Earth Prayers"),  # 21E82B02
+    (0x21E8, 0x2B03, 0x0000, 0x0000, "Rune of Superior Earth Prayers"),  # 21E82B03
+    (0x21E8, 0x2C01, 0x0000, 0x0000, "Rune of Minor Mysticism"),  # 21E82C01
+    (0x21E8, 0x2C02, 0x0000, 0x0000, "Rune of Major Mysticism"),  # 21E82C02
+    (0x21E8, 0x2C03, 0x0000, 0x0000, "Rune of Superior Mysticism"),  # 21E82C03
+    (0x2408, 0x00C2, 0x0000, 0x0000, "Rune of Minor Vigor"),  # 240800C2
+    (0x2408, 0x00FC, 0x0000, 0x0000, "Rune of Minor Absorption"),  # 240800FC
+    (0x2408, 0x00FD, 0x0000, 0x0000, "Rune of Major Absorption"),  # 240800FD
+    (0x2408, 0x00FE, 0x0000, 0x0000, "Rune of Superior Absorption"),  # 240800FE
+    (0x2408, 0x00FF, 0x0000, 0x0000, "Rune of Minor Vigor"),  # 240800FF
+    (0x2408, 0x0100, 0x0000, 0x0000, "Rune of Major Vigor"),  # 24080100
+    (0x2408, 0x0101, 0x0000, 0x0000, "Rune of Superior Vigor"),  # 24080101
+    (0x2408, 0x01DE, 0x0000, 0x0000, "Vanguard's Insignia"),  # 240801DE
+    (0x2408, 0x01DF, 0x0000, 0x0000, "Infiltrator's Insignia"),  # 240801DF
+    (0x2408, 0x01E0, 0x0000, 0x0000, "Saboteur's Insignia"),  # 240801E0
+    (0x2408, 0x01E1, 0x0000, 0x0000, "Nightstalker's Insignia"),  # 240801E1
+    (0x2408, 0x01E2, 0x0000, 0x0000, "Artificer's Insignia"),  # 240801E2
+    (0x2408, 0x01E3, 0x0000, 0x0000, "Prodigy's Insignia"),  # 240801E3
+    (0x2408, 0x01E4, 0x0000, 0x0000, "Virtuoso's Insignia"),  # 240801E4
+    (0x2408, 0x01E5, 0x0000, 0x0000, "Radiant Insignia"),  # 240801E5
+    (0x2408, 0x01E6, 0x0000, 0x0000, "Survivor Insignia"),  # 240801E6
+    (0x2408, 0x01E7, 0x0000, 0x0000, "Stalwart Insignia"),  # 240801E7
+    (0x2408, 0x01E8, 0x0000, 0x0000, "Brawler's Insignia"),  # 240801E8
+    (0x2408, 0x01E9, 0x0000, 0x0000, "Blessed Insignia"),  # 240801E9
+    (0x2408, 0x01EA, 0x0000, 0x0000, "Herald's Insignia"),  # 240801EA
+    (0x2408, 0x01EB, 0x0000, 0x0000, "Sentry's Insignia"),  # 240801EB
+    (0x2408, 0x01EC, 0x0000, 0x0000, "Tormentor's Insignia"),  # 240801EC
+    (0x2408, 0x01ED, 0x0000, 0x0000, "Undertaker's Insignia"),  # 240801ED
+    (0x2408, 0x01EE, 0x0000, 0x0000, "Bonelace Insignia"),  # 240801EE
+    (0x2408, 0x01EF, 0x0000, 0x0000, "Minion Master's Insignia"),  # 240801EF
+    (0x2408, 0x01F0, 0x0000, 0x0000, "Blighter's Insignia"),  # 240801F0
+    (0x2408, 0x01F1, 0x0000, 0x0000, "Prismatic Insignia"),  # 240801F1
+    (0x2408, 0x01F2, 0x0000, 0x0000, "Hydromancer Insignia"),  # 240801F2
+    (0x2408, 0x01F3, 0x0000, 0x0000, "Geomancer Insignia"),  # 240801F3
+    (0x2408, 0x01F4, 0x0000, 0x0000, "Pyromancer Insignia"),  # 240801F4
+    (0x2408, 0x01F5, 0x0000, 0x0000, "Aeromancer Insignia"),  # 240801F5
+    (0x2408, 0x01F6, 0x0000, 0x0000, "Wanderer's Insignia"),  # 240801F6
+    (0x2408, 0x01F7, 0x0000, 0x0000, "Disciple's Insignia"),  # 240801F7
+    (0x2408, 0x01F8, 0x0000, 0x0000, "Anchorite's Insignia"),  # 240801F8
+    (0x2408, 0x01F9, 0x0000, 0x0000, "Knight's Insignia"),  # 240801F9
+    (0x2408, 0x01FA, 0x0000, 0x0000, "Dreadnought Insignia"),  # 240801FA
+    (0x2408, 0x01FB, 0x0000, 0x0000, "Sentinel's Insignia"),  # 240801FB
+    (0x2408, 0x01FC, 0x0000, 0x0000, "Frostbound Insignia"),  # 240801FC
+    (0x2408, 0x01FD, 0x0000, 0x0000, "Earthbound Insignia"),  # 240801FD
+    (0x2408, 0x01FE, 0x0000, 0x0000, "Pyrebound Insignia"),  # 240801FE
+    (0x2408, 0x01FF, 0x0000, 0x0000, "Stormbound Insignia"),  # 240801FF
+    (0x2408, 0x0200, 0x0000, 0x0000, "Beastmaster's Insignia"),  # 24080200
+    (0x2408, 0x0201, 0x0000, 0x0000, "Scout's Insignia"),  # 24080201
+    (0x2408, 0x0202, 0x0000, 0x0000, "Windwalker Insignia"),  # 24080202
+    (0x2408, 0x0203, 0x0000, 0x0000, "Forsaken Insignia"),  # 24080203
+    (0x2408, 0x0204, 0x0000, 0x0000, "Shaman's Insignia"),  # 24080204
+    (0x2408, 0x0205, 0x0000, 0x0000, "Ghost Forge Insignia"),  # 24080205
+    (0x2408, 0x0206, 0x0000, 0x0000, "Mystic's Insignia"),  # 24080206
+    (0x2408, 0x0207, 0x0000, 0x0000, "Centurion's Insignia"),  # 24080207
+    (0x2408, 0x0208, 0x0000, 0x0000, "Lieutenant's Insignia"),  # 24080208
+    (0x2408, 0x0209, 0x0000, 0x0000, "Stonefist Insignia"),  # 24080209
+    (0x2408, 0x020A, 0x0000, 0x0000, "Bloodstained Insignia"),  # 2408020A
+    (0x2408, 0x0211, 0x0000, 0x0000, "Rune of Attunement"),  # 24080211
+    (0x2408, 0x0212, 0x0000, 0x0000, "Rune of Vitae"),  # 24080212
+    (0x2408, 0x0213, 0x0000, 0x0000, "Rune of Recovery"),  # 24080213
+    (0x2408, 0x0214, 0x0000, 0x0000, "Rune of Restoration"),  # 24080214
+    (0x2408, 0x0215, 0x0000, 0x0000, "Rune of Clarity"),  # 24080215
+    (0x2408, 0x0216, 0x0000, 0x0000, "Rune of Purity"),  # 24080216
+]
 
 
 def _build_armor_modifier_lookup():
     lookup = {}
-    for hex_key, label in ARMOR_MODIFIERS_HEX_DATA.items():
-        if not isinstance(hex_key, str) or len(hex_key) != 8:
-            continue
-        try:
-            identifier = int(hex_key[:4], 16)
-            argument = int(hex_key[4:], 16)
-        except ValueError:
-            continue
-        if identifier not in lookup:
-            lookup[identifier] = {}
-        lookup[identifier][argument] = label
+    for identifier, arg, arg1, arg2, label in ARMOR_MODIFIERS_HEX_DATA:
+        lookup.setdefault(identifier, {})[arg] = {
+            "name": label,
+            "arg1": arg1,
+            "arg2": arg2,
+        }
     return lookup
 
 
 _ARMOR_MODIFIER_LOOKUP = _build_armor_modifier_lookup()
-ARMOR_MODIFIER_NAMES = _ARMOR_MODIFIER_LOOKUP.get(0x2408, {})
+ARMOR_MODIFIER_NAMES = {
+    arg: data["name"] for arg, data in _ARMOR_MODIFIER_LOOKUP.get(0x2408, {}).items()
+}
 
 
 def GetArmorModifierName(arg_value: int) -> str:

--- a/Legacy code and tests/ItemCompare.py
+++ b/Legacy code and tests/ItemCompare.py
@@ -262,16 +262,23 @@ def _build_armor_modifier_lookup():
 
 
 _ARMOR_MODIFIER_LOOKUP = _build_armor_modifier_lookup()
-ARMOR_MODIFIER_NAMES = {
-    arg: data["name"] for arg, data in _ARMOR_MODIFIER_LOOKUP.get(0x2408, {}).items()
-}
 
 
-def GetArmorModifierName(arg_value: int) -> str:
+def _get_modifier_entry(identifier: int, arg_value: int):
+    if not isinstance(arg_value, int):
+        return None
+    identifier_lookup = _ARMOR_MODIFIER_LOOKUP.get(identifier)
+    if not identifier_lookup:
+        return None
+    return identifier_lookup.get(arg_value)
+
+
+def GetArmorModifierName(arg_value: int, *, identifier: int = 0x2408) -> str:
     if not isinstance(arg_value, int):
         return str(arg_value)
-    if arg_value in ARMOR_MODIFIER_NAMES:
-        return ARMOR_MODIFIER_NAMES[arg_value]
+    entry = _get_modifier_entry(identifier, arg_value)
+    if entry:
+        return entry["name"]
     return f"Unknown armor modifier (0x{arg_value:04X})"
 
 def find_modifier(identifier: int) -> Optional[ModifierInfo]:
@@ -561,6 +568,19 @@ add_modifier(ModifierInfo(
     arg2="Value",
     arg2_eval_fn=lambda value: Value(value),
     representation=lambda arg, arg1, arg2: f"Armor +{arg2} (while Hexed)"
+))
+
+add_modifier(ModifierInfo(
+    identifier=8680,
+
+    name='Rune Modifier',
+    arg="Modifier",
+    arg_eval_fn=lambda value: GetArmorModifierName(value, identifier=0x21E8),
+    arg1="Attribute",
+    arg1_eval_fn=lambda attribute_id: GetAttributeName(attribute_id),
+    arg2="Tier",
+    arg2_eval_fn=lambda value: Value(value),
+    representation=lambda arg, arg1, arg2: arg if isinstance(arg, str) and not arg.startswith("Unknown") else f"{arg1} rune (tier {arg2})"
 ))
 
 add_modifier(ModifierInfo(

--- a/Legacy code and tests/ItemCompare.py
+++ b/Legacy code and tests/ItemCompare.py
@@ -2,9 +2,6 @@ from Py4GWCoreLib import *
 
 from typing import Optional
 from collections import defaultdict
-from pathlib import Path
-import importlib.util
-import sys
 
 
 module_name = "Mod Handler"
@@ -43,56 +40,233 @@ def add_modifier(modifier):
     modifiers[next_key] = modifier
 
 
-def _resolve_mods_path() -> Optional[Path]:
-    candidates = []
+ARMOR_MODIFIERS_HEX_DATA = {
+    # region warrior
+    "240801F9": "Knight's Insignia",
+    "24080208": "Lieutenant's Insignia",
+    "24080209": "Stonefist Insignia",
+    "240801FA": "Dreadnought Insignia",
+    "240801FB": "Sentinel's Insignia",
+    "240800FC": "Rune of Minor Absorption",
+    "21E81501": "Rune of Minor Tactics",
+    "21E81101": "Rune of Minor Strength",
+    "21E81201": "Rune of Minor Axe Mastery",
+    "21E81301": "Rune of Minor Hammer Mastery",
+    "21E81401": "Rune of Minor Swordsmanship",
+    "240800FD": "Rune of Major Absorption",
+    "21E81502": "Rune of Major Tactics",
+    "21E81102": "Rune of Major Strength",
+    "21E81202": "Rune of Major Axe Mastery",
+    "21E81302": "Rune of Major Hammer Mastery",
+    "21E81402": "Rune of Major Swordsmanship",
+    "240800FE": "Rune of Superior Absorption",
+    "21E81503": "Rune of Superior Tactics",
+    "21E81103": "Rune of Superior Strength",
+    "21E81203": "Rune of Superior Axe Mastery",
+    "21E81303": "Rune of Superior Hammer Mastery",
+    "21E81403": "Rune of Superior Swordsmanship",
+    # endregion
+    # region ranger
+    "240801FC": "Frostbound Insignia",
+    "240801FE": "Pyrebound Insignia",
+    "240801FF": "Stormbound Insignia",
+    "24080201": "Scout's Insignia",
+    "240801FD": "Earthbound Insignia",
+    "24080200": "Beastmaster's Insignia",
+    "21E81801": "Rune of Minor Wilderness Survival",
+    "21E81701": "Rune of Minor Expertise",
+    "21E81601": "Rune of Minor Beast Mastery",
+    "21E81901": "Rune of Minor Marksmanship",
+    "21E81802": "Rune of Major Wilderness Survival",
+    "21E81702": "Rune of Major Expertise",
+    "21E81602": "Rune of Major Beast Mastery",
+    "21E81902": "Rune of Major Marksmanship",
+    "21E81803": "Rune of Superior Wilderness Survival",
+    "21E81703": "Rune of Superior Expertise",
+    "21E81603": "Rune of Superior Beast Mastery",
+    "21E81903": "Rune of Superior Marksmanship",
+    # endregion
+    # region monk
+    "240801F6": "Wanderer's Insignia",
+    "240801F7": "Disciple's Insignia",
+    "240801F8": "Anchorite's Insignia",
+    "21E80D01": "Rune of Minor Healing Prayers",
+    "21E80E01": "Rune of Minor Smiting Prayers",
+    "21E80F01": "Rune of Minor Protection Prayers",
+    "21E81001": "Rune of Minor Divine Favor",
+    "21E80D02": "Rune of Major Healing Prayers",
+    "21E80E02": "Rune of Major Smiting Prayers",
+    "21E80F02": "Rune of Major Protection Prayers",
+    "21E81002": "Rune of Major Divine Favor",
+    "21E80D03": "Rune of Superior Healing Prayers",
+    "21E80E03": "Rune of Superior Smiting Prayers",
+    "21E80F03": "Rune of Superior Protection Prayers",
+    "21E81003": "Rune of Superior Divine Favor",
+    # endregion
+    # region necromancer
+    "2408020A": "Bloodstained Insignia",
+    "240801EC": "Tormentor's Insignia",
+    "240801EE": "Bonelace Insignia",
+    "240801EF": "Minion Master's Insignia",
+    "240801F0": "Blighter's Insignia",
+    "240801ED": "Undertaker's Insignia",
+    "21E80401": "Rune of Minor Blood Magic",
+    "21E80501": "Rune of Minor Death Magic",
+    "21E80701": "Rune of Minor Curses",
+    "21E80601": "Rune of Minor Soul Reaping",
+    "21E80402": "Rune of Major Blood Magic",
+    "21E80502": "Rune of Major Death Magic",
+    "21E80702": "Rune of Major Curses",
+    "21E80602": "Rune of Major Soul Reaping",
+    "21E80403": "Rune of Superior Blood Magic",
+    "21E80503": "Rune of Superior Death Magic",
+    "21E80703": "Rune of Superior Curses",
+    "21E80603": "Rune of Superior Soul Reaping",
+    # endregion
+    # region mesmer
+    "240801E4": "Virtuoso's Insignia",
+    "240801E2": "Artificer's Insignia",
+    "240801E3": "Prodigy's Insignia",
+    "21E80001": "Rune of Minor Fast Casting",
+    "21E80201": "Rune of Minor Domination Magic",
+    "21E80101": "Rune of Minor Illusion Magic",
+    "21E80301": "Rune of Minor Inspiration Magic",
+    "21E80002": "Rune of Major Fast Casting",
+    "21E80202": "Rune of Major Domination Magic",
+    "21E80102": "Rune of Major Illusion Magic",
+    "21E80302": "Rune of Major Inspiration Magic",
+    "21E80003": "Rune of Superior Fast Casting",
+    "21E80203": "Rune of Superior Domination Magic",
+    "21E80103": "Rune of Superior Illusion Magic",
+    "21E80303": "Rune of Superior Inspiration Magic",
+    # endregion
+    # region elementalist
+    "240801F2": "Hydromancer Insignia",
+    "240801F3": "Geomancer Insignia",
+    "240801F4": "Pyromancer Insignia",
+    "240801F5": "Aeromancer Insignia",
+    "240801F1": "Prismatic Insignia",
+    "21E80C01": "Rune of Minor Energy Storage",
+    "21E80A01": "Rune of Minor Fire Magic",
+    "21E80801": "Rune of Minor Air Magic",
+    "21E80901": "Rune of Minor Earth Magic",
+    "21E80B01": "Rune of Minor Water Magic",
+    "21E80C02": "Rune of Major Energy Storage",
+    "21E80A02": "Rune of Major Fire Magic",
+    "21E80802": "Rune of Major Air Magic",
+    "21E80902": "Rune of Major Earth Magic",
+    "21E80B02": "Rune of Major Water Magic",
+    "21E80C03": "Rune of Superior Energy Storage",
+    "21E80A03": "Rune of Superior Fire Magic",
+    "21E80803": "Rune of Superior Air Magic",
+    "21E80903": "Rune of Superior Earth Magic",
+    "21E80B03": "Rune of Superior Water Magic",
+    # endregion
+    # region assassin
+    "240801DE": "Vanguard's Insignia",
+    "240801DF": "Infiltrator's Insignia",
+    "240801E0": "Saboteur's Insignia",
+    "240801E1": "Nightstalker's Insignia",
+    "21E82301": "Rune of Minor Critical Strikes",
+    "21E81D01": "Rune of Minor Dagger Mastery",
+    "21E81E01": "Rune of Minor Deadly Arts",
+    "21E81F01": "Rune of Minor Shadow Arts",
+    "21E82302": "Rune of Major Critical Strikes",
+    "21E81D02": "Rune of Major Dagger Mastery",
+    "21E81E02": "Rune of Major Deadly Arts",
+    "21E81F02": "Rune of Major Shadow Arts",
+    "21E82303": "Rune of Superior Critical Strikes",
+    "21E81D03": "Rune of Superior Dagger Mastery",
+    "21E81E03": "Rune of Superior Deadly Arts",
+    "21E81F03": "Rune of Superior Shadow Arts",
+    # endregion
+    # region ritualist
+    "24080204": "Shaman's Insignia",
+    "24080205": "Ghost Forge Insignia",
+    "24080206": "Mystic's Insignia",
+    "21E82201": "Rune of Minor Channeling Magic",
+    "21E82101": "Rune of Minor Restoration Magic",
+    "21E82001": "Rune of Minor Communing",
+    "21E82401": "Rune of Minor Spawning Power",
+    "21E82202": "Rune of Major Channeling Magic",
+    "21E82102": "Rune of Major Restoration Magic",
+    "21E82002": "Rune of Major Communing",
+    "21E82402": "Rune of Major Spawning Power",
+    "21E82203": "Rune of Superior Channeling Magic",
+    "21E82103": "Rune of Superior Restoration Magic",
+    "21E82003": "Rune of Superior Communing",
+    "21E82403": "Rune of Superior Spawning Power",
+    # endregion
+    # region dervish
+    "24080202": "Windwalker Insignia",
+    "24080203": "Forsaken Insignia",
+    "21E82C01": "Rune of Minor Mysticism",
+    "21E82B01": "Rune of Minor Earth Prayers",
+    "21E82901": "Rune of Minor Scythe Mastery",
+    "21E82A01": "Rune of Minor Wind Prayers",
+    "21E82C02": "Rune of Major Mysticism",
+    "21E82B02": "Rune of Major Earth Prayers",
+    "21E82902": "Rune of Major Scythe Mastery",
+    "21E82A02": "Rune of Major Wind Prayers",
+    "21E82C03": "Rune of Superior Mysticism",
+    "21E82B03": "Rune of Superior Earth Prayers",
+    "21E82903": "Rune of Superior Scythe Mastery",
+    "21E82A03": "Rune of Superior Wind Prayers",
+    # endregion
+    # region paragon
+    "24080207": "Centurion's Insignia",
+    "21E82801": "Rune of Minor Leadership",
+    "21E82701": "Rune of Minor Motivation",
+    "21E82601": "Rune of Minor Command",
+    "21E82501": "Rune of Minor Spear Mastery",
+    "21E82802": "Rune of Major Leadership",
+    "21E82702": "Rune of Major Motivation",
+    "21E82602": "Rune of Major Command",
+    "21E82502": "Rune of Major Spear Mastery",
+    "21E82803": "Rune of Superior Leadership",
+    "21E82703": "Rune of Superior Motivation",
+    "21E82603": "Rune of Superior Command",
+    "21E82503": "Rune of Superior Spear Mastery",
+    # endregion
+    # region common
+    "240801E6": "Survivor Insignia",
+    "240801E5": "Radiant Insignia",
+    "240801E7": "Stalwart Insignia",
+    "240801E8": "Brawler's Insignia",
+    "240801E9": "Blessed Insignia",
+    "240801EA": "Herald's Insignia",
+    "240801EB": "Sentry's Insignia",
+    "24080211": "Rune of Attunement",
+    "24080213": "Rune of Recovery",
+    "24080214": "Rune of Restoration",
+    "24080215": "Rune of Clarity",
+    "24080216": "Rune of Purity",
+    "240800FF": "Rune of Minor Vigor",
+    "240800C2": "Rune of Minor Vigor",
+    "24080101": "Rune of Superior Vigor",
+    "24080100": "Rune of Major Vigor",
+    "24080212": "Rune of Vitae",
+}
 
-    try:
-        this_file = Path(__file__)
-        candidates.append(this_file.parent / "mods.py")
-        candidates.append(this_file.resolve().parent / "mods.py")
-    except NameError:
-        pass
 
-    if sys.argv:
-        candidates.append(Path(sys.argv[0]).resolve().parent / "mods.py")
-
-    for candidate in candidates:
-        try:
-            resolved = candidate.resolve()
-        except (FileNotFoundError, RuntimeError):
+def _build_armor_modifier_lookup():
+    lookup = {}
+    for hex_key, label in ARMOR_MODIFIERS_HEX_DATA.items():
+        if not isinstance(hex_key, str) or len(hex_key) != 8:
             continue
-        if resolved.exists():
-            return resolved
-
-    return None
-
-
-def _load_armor_modifier_names():
-    mods_path = _resolve_mods_path()
-    if not mods_path:
-        return {}
-
-    try:
-        spec = importlib.util.spec_from_file_location("_legacy_mods", mods_path)
-        if spec is None or spec.loader is None:
-            return {}
-        module = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(module)
-    except Exception:
-        return {}
-
-    armor_mods_dict = getattr(module, "armor_mods", {})
-    armor_modifiers = {}
-    for key, value in armor_mods_dict.items():
-        if isinstance(key, str) and key.startswith("2408"):
-            try:
-                armor_modifiers[int(key[4:], 16)] = value
-            except ValueError:
-                continue
-    return armor_modifiers
+        try:
+            identifier = int(hex_key[:4], 16)
+            argument = int(hex_key[4:], 16)
+        except ValueError:
+            continue
+        if identifier not in lookup:
+            lookup[identifier] = {}
+        lookup[identifier][argument] = label
+    return lookup
 
 
-ARMOR_MODIFIER_NAMES = _load_armor_modifier_names()
+_ARMOR_MODIFIER_LOOKUP = _build_armor_modifier_lookup()
+ARMOR_MODIFIER_NAMES = _ARMOR_MODIFIER_LOOKUP.get(0x2408, {})
 
 
 def GetArmorModifierName(arg_value: int) -> str:

--- a/Legacy code and tests/ItemCompare.py
+++ b/Legacy code and tests/ItemCompare.py
@@ -4,6 +4,7 @@ from typing import Optional
 from collections import defaultdict
 from pathlib import Path
 import importlib.util
+import sys
 
 
 module_name = "Mod Handler"
@@ -42,12 +43,33 @@ def add_modifier(modifier):
     modifiers[next_key] = modifier
 
 
-def _load_armor_modifier_names():
+def _resolve_mods_path() -> Optional[Path]:
+    candidates = []
+
     try:
-        mods_path = Path(__file__).with_name("mods.py")
+        this_file = Path(__file__)
+        candidates.append(this_file.parent / "mods.py")
+        candidates.append(this_file.resolve().parent / "mods.py")
     except NameError:
-        return {}
-    if not mods_path.exists():
+        pass
+
+    if sys.argv:
+        candidates.append(Path(sys.argv[0]).resolve().parent / "mods.py")
+
+    for candidate in candidates:
+        try:
+            resolved = candidate.resolve()
+        except (FileNotFoundError, RuntimeError):
+            continue
+        if resolved.exists():
+            return resolved
+
+    return None
+
+
+def _load_armor_modifier_names():
+    mods_path = _resolve_mods_path()
+    if not mods_path:
         return {}
 
     try:

--- a/Legacy code and tests/ItemCompare.py
+++ b/Legacy code and tests/ItemCompare.py
@@ -2,6 +2,8 @@ from Py4GWCoreLib import *
 
 from typing import Optional
 from collections import defaultdict
+from pathlib import Path
+import importlib.util
 
 
 module_name = "Mod Handler"
@@ -38,6 +40,45 @@ def add_modifier(modifier):
     global modifiers
     next_key = len(modifiers)  # Get the next available key
     modifiers[next_key] = modifier
+
+
+def _load_armor_modifier_names():
+    try:
+        mods_path = Path(__file__).with_name("mods.py")
+    except NameError:
+        return {}
+    if not mods_path.exists():
+        return {}
+
+    try:
+        spec = importlib.util.spec_from_file_location("_legacy_mods", mods_path)
+        if spec is None or spec.loader is None:
+            return {}
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    except Exception:
+        return {}
+
+    armor_mods_dict = getattr(module, "armor_mods", {})
+    armor_modifiers = {}
+    for key, value in armor_mods_dict.items():
+        if isinstance(key, str) and key.startswith("2408"):
+            try:
+                armor_modifiers[int(key[4:], 16)] = value
+            except ValueError:
+                continue
+    return armor_modifiers
+
+
+ARMOR_MODIFIER_NAMES = _load_armor_modifier_names()
+
+
+def GetArmorModifierName(arg_value: int) -> str:
+    if not isinstance(arg_value, int):
+        return str(arg_value)
+    if arg_value in ARMOR_MODIFIER_NAMES:
+        return ARMOR_MODIFIER_NAMES[arg_value]
+    return f"Unknown armor modifier (0x{arg_value:04X})"
 
 def find_modifier(identifier: int) -> Optional[ModifierInfo]:
     for mod in modifiers.values():
@@ -617,15 +658,15 @@ add_modifier(ModifierInfo(
 
 add_modifier(ModifierInfo(
     identifier=9224,
-     
-    name='Unknown 9224', 
-    arg="Value", 
-    arg_eval_fn=None, 
-    arg1="Value", 
-    arg1_eval_fn=None, 
-    arg2="Value",
-    arg2_eval_fn=lambda value: Value(value),
-    representation=lambda arg, arg1, arg2: f"{arg} , {arg1} , {arg2}"
+
+    name='Armor Modifier',
+    arg="Modifier",
+    arg_eval_fn=lambda value: GetArmorModifierName(value),
+    arg1="INVALID",
+    arg1_eval_fn=None,
+    arg2="INVALID",
+    arg2_eval_fn=None,
+    representation=lambda arg, arg1, arg2: f"{arg}"
 ))
 
 add_modifier(ModifierInfo(

--- a/Legacy code and tests/ItemCompare.py
+++ b/Legacy code and tests/ItemCompare.py
@@ -871,16 +871,16 @@ add_modifier(ModifierInfo(
 ))
 
 add_modifier(ModifierInfo(
-    identifier=9224,
+    identifier=0x2408,
 
     name='Armor Modifier',
     arg="Modifier",
-    arg_eval_fn=lambda value: GetArmorModifierName(value),
-    arg1="INVALID",
-    arg1_eval_fn=None,
-    arg2="INVALID",
-    arg2_eval_fn=None,
-    representation=lambda arg, arg1, arg2: f"{arg}"
+    arg_eval_fn=lambda value: GetArmorModifierName(value, identifier=0x2408),
+    arg1="High Byte",
+    arg1_eval_fn=lambda value: Value(value),
+    arg2="Low Byte",
+    arg2_eval_fn=lambda value: Value(value),
+    representation=lambda arg, arg1, arg2: arg if isinstance(arg, str) else f"Armor modifier 0x{((arg1 << 8) | (arg2 & 0xFF)):04X}"
 ))
 
 add_modifier(ModifierInfo(


### PR DESCRIPTION
## Summary
- load armor modifier names from the legacy mods list and expose a lookup helper
- use the lookup to render armor modifier entries instead of showing "Unknown 9224"

## Testing
- python -m compileall 'Legacy code and tests/ItemCompare.py'

------
https://chatgpt.com/codex/tasks/task_e_68d6bedd2368832e9e364b92b9994aac