### PR TITLE
Fix quest tester quest info request argument

### DIFF
--- a/Legacy code and tests/quest_tester.py
+++ b/Legacy code and tests/quest_tester.py
@@ -11,10 +11,16 @@ def main():
         if PyImGui.button("get quest log"):
             quest_log = Quest.GetQuestLog()
 
-    for quest_id in quest_log:
+    for quest_entry in quest_log:
+        quest_id = getattr(quest_entry, "quest_id", quest_entry)
+
         if PyImGui.collapsing_header(f"Quest ID: {quest_id}"):
             Quest.RequestQuestInfo(quest_id, update_marker=True)
             quest = Quest.GetQuestData(quest_id)
+
+            if quest is None:
+                PyImGui.text("Quest data unavailable.")
+                continue
 
             PyImGui.text(f"Quest ID: {quest.quest_id}")
             PyImGui.text(f"Log State: {quest.log_state}")


### PR DESCRIPTION
## Summary
- ensure the quest tester extracts quest IDs before requesting quest info
- add a guard for missing quest data when displaying quest details

## Testing
- not run (not applicable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68daa42e5030832e91eeafe56d19fef0