### PR TITLE
Remove cleanup yields from auto pathing coroutines

### DIFF
--- a/auto_pathing_debugger.py
+++ b/auto_pathing_debugger.py
@@ -408,7 +408,6 @@ def _start_plan(auto_follow: bool) -> None:
             )
         finally:
             _is_planning = False
-            yield
 
     GLOBAL_CACHE.Coroutines.append(
         plan_coroutine(smoothing=dict(smoothing_kwargs))
@@ -484,7 +483,6 @@ def _follow_path_coroutine(
             _is_following = False
             _set_pause_reason(None)
             _active_follow_coroutine = None
-            yield
 
     return runner()
 


### PR DESCRIPTION
## Summary
- stop yielding during cleanup in the auto path planning coroutine so shutdown no longer ignores GeneratorExit
- remove the final cleanup yield from the follow-path runner to ensure the coroutine closes cleanly

## Testing
- not run (environment not available)


------
https://chatgpt.com/codex/tasks/task_e_68dbbf12428c832e8104d0cea4ac3710