### PR TITLE
Expose quest text fields

### DIFF
--- a/Legacy code and tests/quest_tester.py
+++ b/Legacy code and tests/quest_tester.py
@@ -12,6 +12,11 @@ export_message = ""
 
 QUEST_FIELDS = (
     ("quest_id", "Quest ID"),
+    ("name", "Name"),
+    ("description", "Description"),
+    ("objectives", "Objectives"),
+    ("location", "Location"),
+    ("npc", "NPC"),
     ("log_state", "Log State"),
     ("map_from", "Map From"),
     ("map_to", "Map To"),

--- a/stubs/PyQuest.pyi
+++ b/stubs/PyQuest.pyi
@@ -2,16 +2,16 @@
 class QuestData:
     quest_id: int
     log_state : int
-    #location :str
-    #name : str
-    #npc : str
+    location: str
+    name: str
+    npc: str
     map_from : int
     map_to : int
     marker_x : float
     marker_y : float
     h0024 : int
-    #description : str
-    #objectives : str
+    description: str
+    objectives: str
     
     is_completed : bool
     is_current_mission_quest : bool


### PR DESCRIPTION
## Summary
- expose quest location, name, npc, description, and objectives in the PyQuest stub
- surface the newly typed quest fields within the quest tester export/UI pipeline

## Testing
- python 'Legacy code and tests/quest_tester.py' *(fails: ModuleNotFoundError: No module named 'Py4GWCoreLib')*

------
https://chatgpt.com/codex/tasks/task_e_68dd3d0db6e4832e81f3d986ea53c298