### PR TITLE
Add demo and docs for calling GWCA exports from Py4GW

### DIFF
--- a/DEMO/DEMO_GWCA_Call.py
+++ b/DEMO/DEMO_GWCA_Call.py
@@ -1,0 +1,50 @@
+import ctypes
+import traceback
+
+import Py4GW  # Py4GW console for logging messages back to the UI
+
+MODULE_NAME = "GWCA Call Demo"
+
+try:
+    GWCA = ctypes.WinDLL("gwca.dll", use_last_error=True)
+    # Ordinal 152 corresponds to ?GetInstanceTime@Map@GW@@YAIXZ in the exported list.
+    GetInstanceTime = ctypes.WINFUNCTYPE(ctypes.c_uint32)((152, GWCA))
+except OSError as load_error:
+    GWCA = None
+    GetInstanceTime = None
+    LOAD_ERROR = load_error
+else:
+    LOAD_ERROR = None
+
+
+def log(message: str, level: int = Py4GW.Console.MessageType.Info) -> None:
+    """Helper that routes log output to the Py4GW console."""
+    Py4GW.Console.Log(MODULE_NAME, message, level)
+
+
+def main() -> None:
+    """Demonstrate calling a GWCA export from Python."""
+    if GWCA is None or GetInstanceTime is None:
+        error_info = f"Failed to load gwca.dll: {LOAD_ERROR}" if LOAD_ERROR else "Unknown load failure"
+        log(error_info, Py4GW.Console.MessageType.Error)
+        win_error = ctypes.get_last_error()
+        if win_error:
+            log(f"Last Win32 error: {win_error}", Py4GW.Console.MessageType.Debug)
+        return
+
+    try:
+        elapsed_ms = GetInstanceTime()
+    except OSError as exc:
+        log(f"GetInstanceTime call failed: {exc}", Py4GW.Console.MessageType.Error)
+        win_error = ctypes.get_last_error()
+        if win_error:
+            log(f"Last Win32 error: {win_error}", Py4GW.Console.MessageType.Debug)
+    except Exception as exc:  # pragma: no cover - defensive logging for unexpected issues
+        log(f"Unexpected error while calling GetInstanceTime: {exc}", Py4GW.Console.MessageType.Error)
+        log(traceback.format_exc(), Py4GW.Console.MessageType.Error)
+    else:
+        log(f"Instance time reported by GWCA: {elapsed_ms} ms")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/calling_gwca_exports.md
+++ b/docs/calling_gwca_exports.md
@@ -1,0 +1,77 @@
+# Calling `gwca.dll` exports from Py4GW scripts
+
+The Guild Wars client exposes a large set of helper functions through `gwca.dll`. Once the
+library is injected you can call any of its exports from a Py4GW script by using the standard
+`ctypes` module.  The steps below show the full workflow and highlight a few common pitfalls.
+
+## 1. Make sure the DLL is loaded
+Py4GW runs inside the Guild Wars process after the launcher injects the automation DLL.  As long
+as your injector has already loaded `gwca.dll` into the game process you can access it straight
+from Python.  No additional initialization is required on the Python side.
+
+```python
+import ctypes
+
+gwca = ctypes.WinDLL("gwca.dll", use_last_error=True)
+```
+
+If the DLL lives under a different name or path, adjust the argument accordingly.  You can verify
+that the load succeeded by checking `ctypes.get_last_error()` or by wrapping the call in a
+`try/except OSError` block.
+
+## 2. Bind a function by ordinal or decorated name
+The export list often contains decorated C++ names (for example
+`?GetInstanceTime@Map@GW@@YAIXZ`).  Calling them by string can be awkward because you must pass the
+exact decorated name.  The export list in the question also contains ordinals, which are easier to
+use with `ctypes`:
+
+```python
+GetInstanceTime = ctypes.WINFUNCTYPE(ctypes.c_uint32)((152, gwca))
+```
+
+`ctypes.WINFUNCTYPE` creates a callable that knows both the return type and the argument types.
+The tuple `(152, gwca)` instructs `ctypes` to bind to export ordinal **152** from the already
+loaded `gwca` module.  Replace `ctypes.c_uint32` and the ordinal with the correct signature for the
+function you want to call.  For exports that take arguments just list their ctypes equivalents after
+the return type, e.g. `ctypes.WINFUNCTYPE(ctypes.c_bool, ctypes.c_uint32, ctypes.c_uint32)`.
+
+If you prefer to bind by name you can do it as well:
+
+```python
+GetInstanceTime = ctypes.WINFUNCTYPE(ctypes.c_uint32)(("?GetInstanceTime@Map@GW@@YAIXZ", gwca))
+```
+
+## 3. Call the function from your script
+Once you have a callable object you can invoke it like a normal Python function.  The snippet below
+uses Py4GW's console to log the value returned by `GetInstanceTime`.
+
+```python
+import Py4GW
+
+MODULE_NAME = "GWCA Call Demo"
+
+def log_instance_time():
+    try:
+        elapsed = GetInstanceTime()
+        Py4GW.Console.Log(
+            MODULE_NAME,
+            f"Instance time: {elapsed} ms",
+            Py4GW.Console.MessageType.Info,
+        )
+    except OSError as exc:
+        Py4GW.Console.Log(
+            MODULE_NAME,
+            f"Failed to call GetInstanceTime: {exc}",
+            Py4GW.Console.MessageType.Error,
+        )
+```
+
+Remember that most GWCA functions expect to be executed from the game thread.  When you are unsure
+whether a call is thread-safe, dispatch it through the game-thread helper provided by Py4GW (for
+example `Py4GW.GameThread.Enqueue` in standard builds) so it runs inside the client's game loop.
+
+## 4. Re-use the binding in multiple scripts
+You can keep the binding logic in a helper module if you need to call several exports from many
+scripts.  The new demo script `DEMO/DEMO_GWCA_Call.py` in this repository shows a complete example
+that you can copy into your own project.  Feel free to adjust the ordinals and signatures to match
+the GWCA function you need.


### PR DESCRIPTION
## Summary
- document how to bind and call gwca.dll exports from Python using ctypes
- add a demo script that logs the instance time using the GetInstanceTime export

## Testing
- not run (documentation and example code only)


------
https://chatgpt.com/codex/tasks/task_e_68dd7eae92e8832ebe430705240ccd4d