### PR TITLE
Add helpers for invoking GWCA exports from Py4GW scripts

### DIFF
--- a/DEMO/DEMO_GWCA_Quest_Demo.py
+++ b/DEMO/DEMO_GWCA_Quest_Demo.py
@@ -19,6 +19,7 @@ from Py4GWCoreLib.Quest import Quest
 MODULE_NAME = "GWCA Quest Demo"
 
 _gwca = GWCALibrary()
+_gwca.initialize()
 _get_active_quest_id = _gwca.get_function(
     "?GetActiveQuestId@QuestMgr@GW@@YA?AW4QuestID@Constants@2@XZ",
     restype=c_uint32,

--- a/DEMO/DEMO_GWCA_Quest_Demo.py
+++ b/DEMO/DEMO_GWCA_Quest_Demo.py
@@ -84,7 +84,7 @@ def draw_window() -> None:
                 quest_id = int(_get_active_quest_id())
             _log(f"GWCA reports active quest ID: {quest_id}")
 
-        PyImGui.same_line()
+        PyImGui.same_line(0.0, -1.0)
         if PyImGui.button("Get active quest (PyQuest)"):
             try:
                 quest_id = Quest.GetActiveQuest()
@@ -96,7 +96,7 @@ def draw_window() -> None:
         if PyImGui.button("Set active quest (GWCA)"):
             _call_bool("SetActiveQuestId", _set_active_quest_id, _quest_id_input)
 
-        PyImGui.same_line()
+        PyImGui.same_line(0.0, -1.0)
         if PyImGui.button("Set active quest (PyQuest)"):
             try:
                 Quest.SetActiveQuest(_quest_id_input)
@@ -113,7 +113,7 @@ def draw_window() -> None:
                 _update_marker,
             )
 
-        PyImGui.same_line()
+        PyImGui.same_line(0.0, -1.0)
         if PyImGui.button("Request quest info (PyQuest)"):
             try:
                 Quest.RequestQuestInfo(_quest_id_input, _update_marker)
@@ -125,7 +125,7 @@ def draw_window() -> None:
         if PyImGui.button("Abandon quest (GWCA)"):
             _call_bool("AbandonQuestId", _abandon_quest_id, _quest_id_input)
 
-        PyImGui.same_line()
+        PyImGui.same_line(0.0, -1.0)
         if PyImGui.button("Abandon quest (PyQuest)"):
             try:
                 Quest.AbandonQuest(_quest_id_input)

--- a/DEMO/DEMO_GWCA_Quest_Demo.py
+++ b/DEMO/DEMO_GWCA_Quest_Demo.py
@@ -14,13 +14,14 @@ import ctypes
 import Py4GW
 import PyImGui
 
-from Py4GWCoreLib import GWCALibrary
+from Py4GWCoreLib import EncodedStringDecoder, GWCALibrary
 from Py4GWCoreLib.Quest import Quest
 
 MODULE_NAME = "GWCA Quest Demo"
 
 _gwca = GWCALibrary()
 _gwca.initialize()
+_string_decoder = EncodedStringDecoder(_gwca, timeout=0.5)
 
 
 class _GamePos(Structure):
@@ -115,15 +116,19 @@ def _call_bool(name: str, func, *args) -> None:
         _log(f"{name} raised {exc!r}")
 
 
-def _wstring_from_ptr(pointer: int | None) -> str | None:
-    """Decode a pointer to a wide-character buffer returned by GWCA."""
+def _decode_encoded_fields(*pointers: int | None) -> List[str | None]:
+    """Resolve encoded quest strings through ``GW::UI::AsyncDecodeStr``."""
 
-    if not pointer:
-        return None
-    try:
-        return ctypes.wstring_at(pointer)
-    except (ValueError, OSError):  # pragma: no cover - defensive path
-        return None
+    decoded_values = _string_decoder.decode_many(list(pointers))
+    results: List[str | None] = []
+    for pointer, decoded in zip(pointers, decoded_values):
+        if decoded is None and pointer:
+            try:
+                decoded = ctypes.wstring_at(pointer)
+            except (ValueError, OSError):  # pragma: no cover - defensive path
+                decoded = None
+        results.append(decoded)
+    return results
 
 
 def _describe_log_state(log_state: int) -> str:
@@ -146,11 +151,18 @@ def _describe_log_state(log_state: int) -> str:
 def _log_quest_details(quest: _QuestStruct) -> None:
     """Pretty-print quest details obtained from ``GWCA::QuestMgr::GetQuest``."""
 
-    name = _wstring_from_ptr(quest.name) or "<unnamed>"
-    location = _wstring_from_ptr(quest.location) or "<unknown category>"
-    npc = _wstring_from_ptr(quest.npc) or "<no giver>"
-    description = _wstring_from_ptr(quest.description) or "<no description>"
-    objectives = _wstring_from_ptr(quest.objectives) or "<no objectives>"
+    name, location, npc, description, objectives = _decode_encoded_fields(
+        int(quest.name) if quest.name else None,
+        int(quest.location) if quest.location else None,
+        int(quest.npc) if quest.npc else None,
+        int(quest.description) if quest.description else None,
+        int(quest.objectives) if quest.objectives else None,
+    )
+    name = name or "<unnamed>"
+    location = location or "<unknown category>"
+    npc = npc or "<no giver>"
+    description = description or "<no description>"
+    objectives = objectives or "<no objectives>"
     _log(f"Quest {quest.quest_id} – {name}")
     _log(f"  Flags: {_describe_log_state(quest.log_state)}")
     _log(f"  Category: {location}")

--- a/DEMO/DEMO_GWCA_Quest_Demo.py
+++ b/DEMO/DEMO_GWCA_Quest_Demo.py
@@ -81,11 +81,25 @@ _update_marker = False
 _logs: List[str] = []
 
 
+def _sanitize_console_text(text: str) -> str:
+    """Replace unsupported surrogate code points before logging."""
+
+    sanitized_chars = []
+    for char in text:
+        codepoint = ord(char)
+        if 0xD800 <= codepoint <= 0xDFFF:
+            sanitized_chars.append("?")
+        else:
+            sanitized_chars.append(char)
+    return "".join(sanitized_chars)
+
+
 def _log(message: str) -> None:
     """Send a message to both the Py4GW console and the ImGui log view."""
 
-    Py4GW.Console.Log(MODULE_NAME, message)
-    _logs.append(message)
+    safe_message = _sanitize_console_text(message)
+    Py4GW.Console.Log(MODULE_NAME, safe_message)
+    _logs.append(safe_message)
     if len(_logs) > 12:
         del _logs[0]
 

--- a/DEMO/DEMO_GWCA_Quest_Demo.py
+++ b/DEMO/DEMO_GWCA_Quest_Demo.py
@@ -7,9 +7,10 @@ with setting, requesting and abandoning quests directly from the DLL.
 """
 from __future__ import annotations
 
-from ctypes import c_bool, c_uint32
+from ctypes import POINTER, Structure, c_bool, c_float, c_uint32, c_void_p
 from typing import List
 
+import ctypes
 import Py4GW
 import PyImGui
 
@@ -20,6 +21,36 @@ MODULE_NAME = "GWCA Quest Demo"
 
 _gwca = GWCALibrary()
 _gwca.initialize()
+
+
+class _GamePos(Structure):
+    """Representation of ``GW::GamePos`` used inside ``GW::Quest``."""
+
+    _fields_ = [
+        ("x", c_float),
+        ("y", c_float),
+        ("plane", c_float),
+    ]
+
+
+class _QuestStruct(Structure):
+    """Mirror of the ``GW::Quest`` structure returned by ``GetQuest``."""
+
+    _fields_ = [
+        ("quest_id", c_uint32),
+        ("log_state", c_uint32),
+        ("location", c_void_p),
+        ("name", c_void_p),
+        ("npc", c_void_p),
+        ("map_from", c_uint32),
+        ("marker", _GamePos),
+        ("_unknown_0x24", c_uint32),
+        ("map_to", c_uint32),
+        ("description", c_void_p),
+        ("objectives", c_void_p),
+    ]
+
+
 _get_active_quest_id = _gwca.get_function(
     "?GetActiveQuestId@QuestMgr@GW@@YA?AW4QuestID@Constants@2@XZ",
     restype=c_uint32,
@@ -38,6 +69,11 @@ _request_quest_info = _gwca.get_function(
     "?RequestQuestInfoId@QuestMgr@GW@@YA_NW4QuestID@Constants@2@_N@Z",
     restype=c_bool,
     argtypes=(c_uint32, c_bool),
+)
+_get_quest = _gwca.get_function(
+    "?GetQuest@QuestMgr@GW@@YAPAUQuest@2@W4QuestID@Constants@2@@Z",
+    restype=POINTER(_QuestStruct),
+    argtypes=(c_uint32,),
 )
 
 _quest_id_input = 0
@@ -63,6 +99,55 @@ def _call_bool(name: str, func, *args) -> None:
         _log(f"{name} {status}")
     except Exception as exc:  # pragma: no cover - runtime feedback
         _log(f"{name} raised {exc!r}")
+
+
+def _wstring_from_ptr(pointer: int | None) -> str | None:
+    """Decode a pointer to a wide-character buffer returned by GWCA."""
+
+    if not pointer:
+        return None
+    try:
+        return ctypes.wstring_at(pointer)
+    except (ValueError, OSError):  # pragma: no cover - defensive path
+        return None
+
+
+def _describe_log_state(log_state: int) -> str:
+    """Return a readable summary of quest flags stored in ``log_state``."""
+
+    flags: List[str] = []
+    if log_state & 0x2:
+        flags.append("completed")
+    if log_state & 0x10:
+        flags.append("mission quest")
+    if log_state & 0x40:
+        flags.append("area primary")
+    if log_state & 0x20:
+        flags.append("primary")
+    if not flags:
+        flags.append("active")
+    return ", ".join(flags)
+
+
+def _log_quest_details(quest: _QuestStruct) -> None:
+    """Pretty-print quest details obtained from ``GWCA::QuestMgr::GetQuest``."""
+
+    name = _wstring_from_ptr(quest.name) or "<unnamed>"
+    location = _wstring_from_ptr(quest.location) or "<unknown category>"
+    npc = _wstring_from_ptr(quest.npc) or "<no giver>"
+    description = _wstring_from_ptr(quest.description) or "<no description>"
+    objectives = _wstring_from_ptr(quest.objectives) or "<no objectives>"
+    _log(f"Quest {quest.quest_id} – {name}")
+    _log(f"  Flags: {_describe_log_state(quest.log_state)}")
+    _log(f"  Category: {location}")
+    _log(f"  NPC: {npc}")
+    _log(
+        "  Marker: x={:.1f}, y={:.1f}, plane={:.1f}".format(
+            quest.marker.x, quest.marker.y, quest.marker.plane
+        )
+    )
+    _log(f"  Description: {description}")
+    _log(f"  Objectives: {objectives}")
 
 
 def draw_window() -> None:
@@ -105,6 +190,17 @@ def draw_window() -> None:
                 _log(f"PyQuest.SetActiveQuest raised {exc!r}")
             else:
                 _log("PyQuest.SetActiveQuest completed")
+
+        if PyImGui.button("Get quest details (GWCA)"):
+            try:
+                quest_ptr = _get_quest(_quest_id_input)
+            except Exception as exc:  # pragma: no cover - runtime feedback
+                _log(f"GetQuest raised {exc!r}")
+            else:
+                if not quest_ptr:
+                    _log("GetQuest returned NULL")
+                else:
+                    _log_quest_details(quest_ptr.contents)
 
         if PyImGui.button("Request quest info (GWCA)"):
             _call_bool(

--- a/DEMO/DEMO_GWCA_Quest_Demo.py
+++ b/DEMO/DEMO_GWCA_Quest_Demo.py
@@ -1,0 +1,153 @@
+"""Interactive demo for quest-related GWCA exports.
+
+This script showcases how to call quest functions exposed by ``GWCA.dll``
+through the :class:`Py4GWCoreLib.GWCA.GWCALibrary` helper.  Launch it from
+Py4GW while the Guild Wars client is running with GWCA injected to experiment
+with setting, requesting and abandoning quests directly from the DLL.
+"""
+from __future__ import annotations
+
+from ctypes import c_bool, c_uint32
+from typing import List
+
+import Py4GW
+import PyImGui
+
+from Py4GWCoreLib import GWCALibrary
+from Py4GWCoreLib.Quest import Quest
+
+MODULE_NAME = "GWCA Quest Demo"
+
+_gwca = GWCALibrary()
+_get_active_quest_id = _gwca.get_function(
+    "?GetActiveQuestId@QuestMgr@GW@@YA?AW4QuestID@Constants@2@XZ",
+    restype=c_uint32,
+)
+_set_active_quest_id = _gwca.get_function(
+    "?SetActiveQuestId@QuestMgr@GW@@YA_NW4QuestID@Constants@2@@Z",
+    restype=c_bool,
+    argtypes=(c_uint32,),
+)
+_abandon_quest_id = _gwca.get_function(
+    "?AbandonQuestId@QuestMgr@GW@@YA_NW4QuestID@Constants@2@@Z",
+    restype=c_bool,
+    argtypes=(c_uint32,),
+)
+_request_quest_info = _gwca.get_function(
+    "?RequestQuestInfoId@QuestMgr@GW@@YA_NW4QuestID@Constants@2@_N@Z",
+    restype=c_bool,
+    argtypes=(c_uint32, c_bool),
+)
+
+_quest_id_input = 0
+_update_marker = False
+_logs: List[str] = []
+
+
+def _log(message: str) -> None:
+    """Send a message to both the Py4GW console and the ImGui log view."""
+
+    Py4GW.Console.Log(MODULE_NAME, message)
+    _logs.append(message)
+    if len(_logs) > 12:
+        del _logs[0]
+
+
+def _call_bool(name: str, func, *args) -> None:
+    """Call a GWCA function and record its success state."""
+
+    try:
+        success = bool(func(*args))
+        status = "succeeded" if success else "failed"
+        _log(f"{name} {status}")
+    except Exception as exc:  # pragma: no cover - runtime feedback
+        _log(f"{name} raised {exc!r}")
+
+
+def draw_window() -> None:
+    """Render the ImGui window that exposes the quest helpers."""
+
+    global _quest_id_input
+    global _update_marker
+
+    if PyImGui.begin(MODULE_NAME):
+        PyImGui.text("Interact with quest exports provided by GWCA.dll")
+        PyImGui.separator()
+
+        _quest_id_input = PyImGui.input_int("Quest ID", _quest_id_input)
+        _update_marker = PyImGui.checkbox("Update quest marker", _update_marker)
+
+        if PyImGui.button("Get active quest (GWCA)"):
+            try:
+                quest_id = int(_get_active_quest_id().value)
+            except AttributeError:
+                quest_id = int(_get_active_quest_id())
+            _log(f"GWCA reports active quest ID: {quest_id}")
+
+        PyImGui.same_line()
+        if PyImGui.button("Get active quest (PyQuest)"):
+            try:
+                quest_id = Quest.GetActiveQuest()
+            except Exception as exc:  # pragma: no cover - runtime feedback
+                _log(f"PyQuest.GetActiveQuest raised {exc!r}")
+            else:
+                _log(f"PyQuest reports active quest ID: {quest_id}")
+
+        if PyImGui.button("Set active quest (GWCA)"):
+            _call_bool("SetActiveQuestId", _set_active_quest_id, _quest_id_input)
+
+        PyImGui.same_line()
+        if PyImGui.button("Set active quest (PyQuest)"):
+            try:
+                Quest.SetActiveQuest(_quest_id_input)
+            except Exception as exc:  # pragma: no cover - runtime feedback
+                _log(f"PyQuest.SetActiveQuest raised {exc!r}")
+            else:
+                _log("PyQuest.SetActiveQuest completed")
+
+        if PyImGui.button("Request quest info (GWCA)"):
+            _call_bool(
+                "RequestQuestInfoId",
+                _request_quest_info,
+                _quest_id_input,
+                _update_marker,
+            )
+
+        PyImGui.same_line()
+        if PyImGui.button("Request quest info (PyQuest)"):
+            try:
+                Quest.RequestQuestInfo(_quest_id_input, _update_marker)
+            except Exception as exc:  # pragma: no cover - runtime feedback
+                _log(f"PyQuest.RequestQuestInfo raised {exc!r}")
+            else:
+                _log("PyQuest.RequestQuestInfo completed")
+
+        if PyImGui.button("Abandon quest (GWCA)"):
+            _call_bool("AbandonQuestId", _abandon_quest_id, _quest_id_input)
+
+        PyImGui.same_line()
+        if PyImGui.button("Abandon quest (PyQuest)"):
+            try:
+                Quest.AbandonQuest(_quest_id_input)
+            except Exception as exc:  # pragma: no cover - runtime feedback
+                _log(f"PyQuest.AbandonQuest raised {exc!r}")
+            else:
+                _log("PyQuest.AbandonQuest completed")
+
+        PyImGui.separator()
+        PyImGui.text("Recent calls:")
+        for entry in _logs:
+            PyImGui.bullet_text(entry)
+
+        PyImGui.end()
+
+
+def main() -> None:
+    try:
+        draw_window()
+    except Exception as exc:  # pragma: no cover - runtime feedback
+        Py4GW.Console.Log(MODULE_NAME, f"Unexpected error: {exc!r}")
+
+
+if __name__ == "__main__":
+    main()

--- a/Py4GWCoreLib/GWCA.py
+++ b/Py4GWCoreLib/GWCA.py
@@ -9,7 +9,7 @@ arguments and return types to matching ``ctypes`` declarations.
 from __future__ import annotations
 
 import ctypes
-from ctypes import wintypes
+from ctypes import c_bool, wintypes
 from typing import Optional, Sequence, Union
 
 __all__ = ["GWCALibrary", "load_gwca_function"]
@@ -61,12 +61,26 @@ class GWCALibrary:
             self._stdcall = ctypes.WinDLL(module_name, handle=wrapped_handle)
         self._handle = handle
         self._default_call_conv = default_call_conv.lower()
+        self._initialized = False
+
+        if not self.initialize():
+            raise RuntimeError("GWCA::Initialize() failed")
 
     @property
     def handle(self) -> int:
         """Return the raw ``HMODULE`` handle."""
 
         return self._handle.value
+
+    def initialize(self) -> bool:
+        """Ensure ``GWCA::Initialize`` ran successfully."""
+
+        if not self._initialized:
+            initialize = self.get_function(
+                "?Initialize@GW@@YA_NXZ", restype=c_bool
+            )
+            self._initialized = bool(initialize())
+        return self._initialized
 
     def get_function(
         self,

--- a/Py4GWCoreLib/GWCA.py
+++ b/Py4GWCoreLib/GWCA.py
@@ -9,10 +9,11 @@ arguments and return types to matching ``ctypes`` declarations.
 from __future__ import annotations
 
 import ctypes
-from ctypes import c_bool, wintypes
+from ctypes import c_bool, c_uint32, wintypes
+import threading
 from typing import Optional, Sequence, Union
 
-__all__ = ["GWCALibrary", "load_gwca_function"]
+__all__ = ["GWCALibrary", "EncodedStringDecoder", "load_gwca_function"]
 
 
 class GWCALibrary:
@@ -136,6 +137,124 @@ class GWCALibrary:
         if restype is not None:
             func.restype = restype
         return func
+
+
+class EncodedStringDecoder:
+    """Decode Guild Wars encoded strings via ``GW::UI::AsyncDecodeStr``.
+
+    Guild Wars stores many localized strings in an encoded wide-character
+    format.  ``GWCA.dll`` exposes ``AsyncDecodeStr`` which resolves those
+    strings asynchronously on the game thread.  This helper mirrors the
+    behaviour of GWToolbox's ``GuiUtils::EncString`` so Python scripts can
+    synchronously obtain decoded text for quest names, item descriptions and
+    similar fields.
+
+    Parameters
+    ----------
+    library:
+        Active :class:`GWCALibrary` instance used to look up ``AsyncDecodeStr``.
+    timeout:
+        Maximum time in seconds to wait for each string to decode before
+        falling back to the raw encoded value.
+    language:
+        Optional ``GW::Constants::Language`` override.  The default (``0xFF``)
+        lets the client pick the currently active language.
+    """
+
+    _DecodeCallback = ctypes.CFUNCTYPE(None, ctypes.py_object, ctypes.c_wchar_p)
+
+    class _DecodeState:
+        __slots__ = ("event", "result", "encoded")
+
+        def __init__(self, encoded: ctypes.c_wchar_p) -> None:
+            self.event = threading.Event()
+            self.result: str | None = None
+            # Keep a reference to the encoded pointer object alive until the
+            # asynchronous decode finishes.
+            self.encoded = encoded
+
+    def __init__(
+        self,
+        library: GWCALibrary,
+        *,
+        timeout: float = 0.5,
+        language: int = 0xFF,
+    ) -> None:
+        self._timeout = timeout
+        self._language = language
+        self._callback = self._DecodeCallback(self._on_decoded)
+        self._decode = library.get_function(
+            "?AsyncDecodeStr@UI@GW@@YAXPB_WP6AXPAX0@Z1W4Language@Constants@2@@Z",
+            restype=None,
+            argtypes=(
+                ctypes.c_wchar_p,
+                self._DecodeCallback,
+                ctypes.py_object,
+                c_uint32,
+            ),
+        )
+        self._lock = threading.Lock()
+        self._pending: set[EncodedStringDecoder._DecodeState] = set()
+
+    def _start_decode(self, encoded: ctypes.c_wchar_p) -> _DecodeState:
+        state = self._DecodeState(encoded)
+        with self._lock:
+            self._pending.add(state)
+        try:
+            self._decode(encoded, self._callback, state, self._language)
+        except Exception:
+            with self._lock:
+                self._pending.discard(state)
+            raise
+        return state
+
+    def _on_decoded(self, state: _DecodeState, decoded: str | None) -> None:
+        state.result = decoded or ""
+        state.event.set()
+        with self._lock:
+            self._pending.discard(state)
+
+    def decode_many(self, pointers: Sequence[int | None]) -> list[str | None]:
+        """Decode multiple encoded string pointers at once."""
+
+        states: list[tuple[EncodedStringDecoder._DecodeState | None, str | None]] = []
+        for pointer in pointers:
+            if not pointer:
+                states.append((None, None))
+                continue
+            try:
+                address = int(pointer)
+            except (TypeError, ValueError):
+                address = pointer
+            encoded = ctypes.cast(ctypes.c_void_p(address), ctypes.c_wchar_p)
+            try:
+                raw_value = encoded.value
+            except (ValueError, OSError):
+                states.append((None, None))
+                continue
+            if raw_value in (None, ""):
+                states.append((None, raw_value or ""))
+                continue
+            state = self._start_decode(encoded)
+            states.append((state, raw_value))
+
+        results: list[str | None] = []
+        for state, fallback in states:
+            if state is None:
+                results.append(fallback)
+                continue
+            if state.event.wait(self._timeout) and state.result is not None:
+                results.append(state.result)
+            elif state.event.is_set() and state.result is not None:
+                results.append(state.result)
+            else:
+                results.append(fallback)
+        return results
+
+    def decode_pointer(self, pointer: int | None) -> str | None:
+        """Decode a single encoded string pointer."""
+
+        return self.decode_many([pointer])[0]
 
 
 def load_gwca_function(

--- a/Py4GWCoreLib/GWCA.py
+++ b/Py4GWCoreLib/GWCA.py
@@ -56,8 +56,9 @@ class GWCALibrary:
             handle = wintypes.HMODULE(self._cdecl._handle)
         else:
             # Wrap the existing handle without reloading the DLL.
-            self._cdecl = ctypes.CDLL(None, handle=handle.value)
-            self._stdcall = ctypes.WinDLL(None, handle=handle.value)
+            wrapped_handle = int(handle.value)
+            self._cdecl = ctypes.CDLL(module_name, handle=wrapped_handle)
+            self._stdcall = ctypes.WinDLL(module_name, handle=wrapped_handle)
         self._handle = handle
         self._default_call_conv = default_call_conv.lower()
 

--- a/Py4GWCoreLib/GWCA.py
+++ b/Py4GWCoreLib/GWCA.py
@@ -1,0 +1,147 @@
+"""Helpers for calling exported functions from GWCA.dll.
+
+This module offers a thin wrapper around :mod:`ctypes` so Py4GW scripts can
+bind decorated exports from ``GWCA.dll`` (the Guild Wars Client API library).
+The helpers only deal with obtaining the function pointer and applying the
+correct calling convention; scripts are still responsible for mapping the
+arguments and return types to matching ``ctypes`` declarations.
+"""
+from __future__ import annotations
+
+import ctypes
+from ctypes import wintypes
+from typing import Optional, Sequence, Union
+
+__all__ = ["GWCALibrary", "load_gwca_function"]
+
+
+class GWCALibrary:
+    """Lightweight loader for ``GWCA.dll`` exports.
+
+    Parameters
+    ----------
+    module_name:
+        Name of the DLL to load. Defaults to ``"GWCA.dll"`` which is the
+        canonical name shipped with GWToolbox/Py4GW setups.
+    prefer_loaded:
+        If ``True`` (the default) and the module is already loaded inside the
+        current process the existing handle is reused. Reusing the handle avoids
+        accidentally loading a second copy of the library which would fail to
+        see Guild Wars' game state.
+    default_call_conv:
+        Either ``"cdecl"`` or ``"stdcall"``. GWCA exports are declared with
+        the default ``__cdecl`` calling convention, but the parameter is
+        exposed so that scripts can opt into ``stdcall`` when binding custom
+        hooks or third-party exports.
+    """
+
+    def __init__(
+        self,
+        module_name: str = "GWCA.dll",
+        *,
+        prefer_loaded: bool = True,
+        default_call_conv: str = "cdecl",
+    ) -> None:
+        self._module_name = module_name
+        self._kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        handle = wintypes.HMODULE()
+        if prefer_loaded:
+            existing = self._kernel32.GetModuleHandleW(module_name)
+            if existing:
+                handle = wintypes.HMODULE(existing)
+        if not handle.value:
+            # ``CDLL``/``WinDLL`` load the module if it is not already present.
+            self._cdecl = ctypes.CDLL(module_name)
+            self._stdcall = ctypes.WinDLL(module_name)
+            handle = wintypes.HMODULE(self._cdecl._handle)
+        else:
+            # Wrap the existing handle without reloading the DLL.
+            self._cdecl = ctypes.CDLL(None, handle=handle.value)
+            self._stdcall = ctypes.WinDLL(None, handle=handle.value)
+        self._handle = handle
+        self._default_call_conv = default_call_conv.lower()
+
+    @property
+    def handle(self) -> int:
+        """Return the raw ``HMODULE`` handle."""
+
+        return self._handle.value
+
+    def get_function(
+        self,
+        symbol: Union[str, int],
+        *,
+        restype: Optional[ctypes._CData] = None,
+        argtypes: Sequence[ctypes._CData] | None = None,
+        call_conv: Optional[str] = None,
+    ) -> ctypes._CFuncPtr:
+        """Return a callable ctypes wrapper for an exported function.
+
+        Parameters
+        ----------
+        symbol:
+            Either the decorated export name (for example,
+            ``"?GetMapID@Map@GW@@YA?AW4MapID@Constants@2@XZ"``) or the ordinal
+            number published by the DLL (``193`` for ``GetMapID`` in the list
+            provided by GWCA).
+        restype:
+            ``ctypes`` type that describes the function's return value. ``None``
+            (the default) makes the wrapper behave like a ``void`` function.
+        argtypes:
+            Sequence describing the argument types for ``ctypes``. Providing it
+            enables automatic type conversion and stack validation.
+        call_conv:
+            Override for the calling convention. ``"cdecl"`` uses the ``CDLL``
+            binding while ``"stdcall"`` uses the ``WinDLL`` binding.
+
+        Returns
+        -------
+        ``ctypes._CFuncPtr``
+            A ready-to-use callable that can be invoked directly from Python.
+        """
+
+        binding = (call_conv or self._default_call_conv).lower()
+        if binding not in {"cdecl", "stdcall"}:
+            raise ValueError("call_conv must be either 'cdecl' or 'stdcall'")
+
+        library = self._cdecl if binding == "cdecl" else self._stdcall
+        if isinstance(symbol, int):
+            lookup = f"#{symbol}"
+        else:
+            lookup = symbol
+        try:
+            func = getattr(library, lookup)
+        except AttributeError as exc:  # pragma: no cover - defensive path
+            raise AttributeError(
+                f"Function '{symbol}' not found in {self._module_name}"
+            ) from exc
+
+        if argtypes is not None:
+            func.argtypes = list(argtypes)
+        if restype is not None:
+            func.restype = restype
+        return func
+
+
+def load_gwca_function(
+    symbol: Union[str, int],
+    *,
+    restype: Optional[ctypes._CData] = None,
+    argtypes: Sequence[ctypes._CData] | None = None,
+    call_conv: str = "cdecl",
+    module_name: str = "GWCA.dll",
+    prefer_loaded: bool = True,
+) -> ctypes._CFuncPtr:
+    """Convenience wrapper that instantiates :class:`GWCALibrary` on demand."""
+
+    library = GWCALibrary(
+        module_name=module_name,
+        prefer_loaded=prefer_loaded,
+        default_call_conv=call_conv,
+    )
+    return library.get_function(
+        symbol,
+        restype=restype,
+        argtypes=argtypes,
+        call_conv=call_conv,
+    )

--- a/Py4GWCoreLib/__init__.py
+++ b/Py4GWCoreLib/__init__.py
@@ -46,7 +46,7 @@ from .Effect import *
 from .Merchant import *
 from .Quest import *
 from .Camera import *
-from .GWCA import GWCALibrary, load_gwca_function
+from .GWCA import EncodedStringDecoder, GWCALibrary, load_gwca_function
 
 from .Py4GWcorelib import *
 from .Overlay import *

--- a/Py4GWCoreLib/__init__.py
+++ b/Py4GWCoreLib/__init__.py
@@ -46,6 +46,7 @@ from .Effect import *
 from .Merchant import *
 from .Quest import *
 from .Camera import *
+from .GWCA import GWCALibrary, load_gwca_function
 
 from .Py4GWcorelib import *
 from .Overlay import *

--- a/docs/gwca_function_calls.md
+++ b/docs/gwca_function_calls.md
@@ -109,6 +109,32 @@ if quest_ptr:
     quest_name = ctypes.wstring_at(quest.name) if quest.name else None
 ```
 
+## 4. Decode encoded strings returned by Guild Wars
+
+Many fields exposed by GWCA (quest names, item descriptions, agent names,
+etc.) are stored as encoded ``wchar_t`` buffers inside the client.  Toolbox
+wraps them in ``GuiUtils::EncString`` so the Guild Wars UI thread can decode
+the localized text asynchronously.  ``Py4GWCoreLib.GWCA`` now provides a
+matching :class:`EncodedStringDecoder` helper that mirrors this behaviour:
+
+```python
+from Py4GWCoreLib import EncodedStringDecoder, GWCALibrary
+
+gwca = GWCALibrary()
+decoder = EncodedStringDecoder(gwca)
+
+quest = get_quest(quest_id).contents
+name, description = decoder.decode_many([
+    int(quest.name) if quest.name else None,
+    int(quest.description) if quest.description else None,
+])
+```
+
+The helper queues ``GW::UI::AsyncDecodeStr`` calls and waits briefly for the
+callback so scripts receive human-readable strings inside the same frame.
+Fallback logic keeps the encoded text available if decoding takes longer than
+expected.【F:Py4GWCoreLib/GWCA.py†L142-L257】
+
 ## Tips
 
 * Keep using the Py4GW helper APIs (agents, inventory, etc.) whenever they

--- a/docs/gwca_function_calls.md
+++ b/docs/gwca_function_calls.md
@@ -65,7 +65,49 @@ use_skill(skill_id, current_target)
 
 Because the return value and parameter types are backed by `ctypes`, Python
 will automatically marshal integral values for you. For pointers or structures
-create the corresponding `ctypes` definitions before binding the function.
+create the corresponding `ctypes` definitions before binding the function. For
+example, the quest demo maps `GW::Quest` and its nested `GW::GamePos` before
+calling `GW::QuestMgr::GetQuest`:
+
+```python
+import ctypes
+from ctypes import POINTER, Structure, c_float, c_uint32, c_void_p
+
+
+class GamePos(Structure):
+    _fields_ = [
+        ("x", c_float),
+        ("y", c_float),
+        ("plane", c_float),
+    ]
+
+
+class QuestStruct(Structure):
+    _fields_ = [
+        ("quest_id", c_uint32),
+        ("log_state", c_uint32),
+        ("location", c_void_p),
+        ("name", c_void_p),
+        ("npc", c_void_p),
+        ("map_from", c_uint32),
+        ("marker", GamePos),
+        ("_unknown_0x24", c_uint32),
+        ("map_to", c_uint32),
+        ("description", c_void_p),
+        ("objectives", c_void_p),
+    ]
+
+
+get_quest = gwca.get_function(
+    "?GetQuest@QuestMgr@GW@@YAPAUQuest@2@W4QuestID@Constants@2@@Z",
+    restype=POINTER(QuestStruct),
+    argtypes=(c_uint32,),
+)
+quest_ptr = get_quest(quest_id)
+if quest_ptr:
+    quest = quest_ptr.contents
+    quest_name = ctypes.wstring_at(quest.name) if quest.name else None
+```
 
 ## Tips
 

--- a/docs/gwca_function_calls.md
+++ b/docs/gwca_function_calls.md
@@ -1,0 +1,76 @@
+# Calling functions exported by `GWCA.dll`
+
+When the Guild Wars client has `GWCA.dll` injected you can call any of its
+exports from a Py4GW script.  The new `Py4GWCoreLib.GWCA` helper removes the
+boilerplate usually required to bind decorated C++ exports with `ctypes`.
+
+## 1. Load the library once
+
+```python
+from Py4GWCoreLib import GWCALibrary
+
+gwca = GWCALibrary()  # reuses the already-injected module inside Guild Wars
+```
+
+`GWCALibrary` looks for an existing copy of the DLL inside the game process
+and reuses that handle so you are always talking to the injected module rather
+than loading a new copy.【F:Py4GWCoreLib/GWCA.py†L41-L57】
+
+If you only need a single function you can skip the explicit instance and call
+`load_gwca_function(...)` instead, which internally constructs a
+`GWCALibrary` and returns the bound callable.【F:Py4GWCoreLib/GWCA.py†L102-L118】
+
+## 2. Bind the function you need
+
+Pass either the decorated export name or the ordinal from your dump together
+with the expected signature:
+
+```python
+from ctypes import c_bool, c_uint32
+
+# Using the decorated name
+destroy_item = gwca.get_function(
+    "?DestroyItem@Items@GW@@YA_NI@Z",
+    restype=c_bool,
+    argtypes=(c_uint32,),
+)
+
+# Using the ordinal number (466 == UseSkill in the table you provided)
+use_skill = gwca.get_function(
+    466,
+    restype=c_bool,
+    argtypes=(c_uint32, c_uint32),
+)
+```
+
+The helper accepts either `cdecl` (GWCA’s default) or `stdcall` bindings and
+exposes them via the `call_conv` parameter when needed.【F:Py4GWCoreLib/GWCA.py†L59-L100】
+
+## 3. Call the function inside your script
+
+```python
+item_id = 0x12345678
+if destroy_item(item_id):
+    print(f"Destroyed item {item_id:#x}")
+
+skill_id = 5
+current_target = 0  # use 0 to keep the current target
+gwca.Console.Log("demo", f"Use skill {skill_id}")
+use_skill(skill_id, current_target)
+```
+
+Because the return value and parameter types are backed by `ctypes`, Python
+will automatically marshal integral values for you. For pointers or structures
+create the corresponding `ctypes` definitions before binding the function.
+
+## Tips
+
+* Keep using the Py4GW helper APIs (agents, inventory, etc.) whenever they
+  already expose the behaviour you need. Drop down to `GWCA.dll` only for
+  features that have not been wrapped yet.
+* Many GWCA exports expect to be executed on the Guild Wars game thread. Use
+  the existing `GameThread` utilities from Py4GW when you need to enqueue work
+  there before calling into GWCA.
+* Invalid signatures or incorrect calling conventions typically crash the
+  Guild Wars client. Double-check the parameters against the GWCA headers in
+  `external/GWToolboxpp/Dependencies/GWCA/include` when in doubt.

--- a/docs/gwca_function_calls.md
+++ b/docs/gwca_function_calls.md
@@ -4,17 +4,21 @@ When the Guild Wars client has `GWCA.dll` injected you can call any of its
 exports from a Py4GW script.  The new `Py4GWCoreLib.GWCA` helper removes the
 boilerplate usually required to bind decorated C++ exports with `ctypes`.
 
-## 1. Load the library once
+## 1. Load the library and call `Initialize`
 
 ```python
 from Py4GWCoreLib import GWCALibrary
 
 gwca = GWCALibrary()  # reuses the already-injected module inside Guild Wars
+gwca.initialize()     # ensures GWCA scanned memory and installed its hooks
 ```
 
 `GWCALibrary` looks for an existing copy of the DLL inside the game process
 and reuses that handle so you are always talking to the injected module rather
-than loading a new copy.【F:Py4GWCoreLib/GWCA.py†L41-L57】
+than loading a new copy.【F:Py4GWCoreLib/GWCA.py†L41-L57】  During construction it
+invokes `GWCA::Initialize` and raises an error if the call fails, but invoking
+`initialize()` explicitly at the start of your script makes the dependency
+obvious and lets you retry in custom workflows.【F:Py4GWCoreLib/GWCA.py†L59-L80】
 
 If you only need a single function you can skip the explicit instance and call
 `load_gwca_function(...)` instead, which internally constructs a


### PR DESCRIPTION
## Summary
- add a reusable GWCA.dll loader that exposes decorated exports through ctypes
- surface the loader from Py4GWCoreLib for convenience and document how to use it

## Testing
- python -m compileall Py4GWCoreLib/GWCA.py

------
https://chatgpt.com/codex/tasks/task_e_68dd7eae92e8832ebe430705240ccd4d