### PR TITLE
Decode GW quest strings via AsyncDecodeStr

### DIFF
--- a/DEMO/DEMO_GWCA_Quest_Demo.py
+++ b/DEMO/DEMO_GWCA_Quest_Demo.py
@@ -1,0 +1,322 @@
+"""Interactive demo for quest-related GWCA exports.
+
+This script showcases how to call quest functions exposed by ``GWCA.dll``
+through the :class:`Py4GWCoreLib.GWCA.GWCALibrary` helper.  Launch it from
+Py4GW while the Guild Wars client is running with GWCA injected to experiment
+with setting, requesting and abandoning quests directly from the DLL.
+"""
+from __future__ import annotations
+
+from ctypes import (
+    POINTER,
+    Structure,
+    c_bool,
+    c_float,
+    c_uint32,
+    c_void_p,
+    c_wchar_p,
+)
+from typing import List, Optional
+
+import ctypes
+import re
+import threading
+import Py4GW
+import PyImGui
+
+from Py4GWCoreLib import GWCALibrary
+from Py4GWCoreLib.Quest import Quest
+
+MODULE_NAME = "GWCA Quest Demo"
+
+_gwca = GWCALibrary()
+_gwca.initialize()
+
+
+class _GamePos(Structure):
+    """Representation of ``GW::GamePos`` used inside ``GW::Quest``."""
+
+    _fields_ = [
+        ("x", c_float),
+        ("y", c_float),
+        ("plane", c_float),
+    ]
+
+
+class _QuestStruct(Structure):
+    """Mirror of the ``GW::Quest`` structure returned by ``GetQuest``."""
+
+    _fields_ = [
+        ("quest_id", c_uint32),
+        ("log_state", c_uint32),
+        ("location", c_void_p),
+        ("name", c_void_p),
+        ("npc", c_void_p),
+        ("map_from", c_uint32),
+        ("marker", _GamePos),
+        ("_unknown_0x24", c_uint32),
+        ("map_to", c_uint32),
+        ("description", c_void_p),
+        ("objectives", c_void_p),
+    ]
+
+
+_get_active_quest_id = _gwca.get_function(
+    "?GetActiveQuestId@QuestMgr@GW@@YA?AW4QuestID@Constants@2@XZ",
+    restype=c_uint32,
+)
+_set_active_quest_id = _gwca.get_function(
+    "?SetActiveQuestId@QuestMgr@GW@@YA_NW4QuestID@Constants@2@@Z",
+    restype=c_bool,
+    argtypes=(c_uint32,),
+)
+_abandon_quest_id = _gwca.get_function(
+    "?AbandonQuestId@QuestMgr@GW@@YA_NW4QuestID@Constants@2@@Z",
+    restype=c_bool,
+    argtypes=(c_uint32,),
+)
+_request_quest_info = _gwca.get_function(
+    "?RequestQuestInfoId@QuestMgr@GW@@YA_NW4QuestID@Constants@2@_N@Z",
+    restype=c_bool,
+    argtypes=(c_uint32, c_bool),
+)
+_get_quest = _gwca.get_function(
+    "?GetQuest@QuestMgr@GW@@YAPAUQuest@2@W4QuestID@Constants@2@@Z",
+    restype=POINTER(_QuestStruct),
+    argtypes=(c_uint32,),
+)
+
+_DecodeStrCallback = ctypes.CFUNCTYPE(None, c_void_p, c_wchar_p)
+_async_decode_str = _gwca.get_function(
+    "?AsyncDecodeStr@UI@GW@@YAXPB_WP6AXPAX0@Z1W4Language@Constants@2@@Z",
+    argtypes=(c_wchar_p, _DecodeStrCallback, c_void_p, c_uint32),
+)
+_DEFAULT_LANGUAGE = 0xFF
+
+_quest_id_input = 0
+_update_marker = False
+_logs: List[str] = []
+
+
+def _sanitize_console_text(text: str) -> str:
+    """Replace unsupported surrogate code points before logging."""
+
+    sanitized_chars = []
+    for char in text:
+        codepoint = ord(char)
+        if 0xD800 <= codepoint <= 0xDFFF:
+            sanitized_chars.append("?")
+        else:
+            sanitized_chars.append(char)
+    return "".join(sanitized_chars)
+
+
+def _log(message: str) -> None:
+    """Send a message to both the Py4GW console and the ImGui log view."""
+
+    safe_message = _sanitize_console_text(message)
+    Py4GW.Console.Log(MODULE_NAME, safe_message)
+    _logs.append(safe_message)
+    if len(_logs) > 12:
+        del _logs[0]
+
+
+def _call_bool(name: str, func, *args) -> None:
+    """Call a GWCA function and record its success state."""
+
+    try:
+        success = bool(func(*args))
+        status = "succeeded" if success else "failed"
+        _log(f"{name} {status}")
+    except Exception as exc:  # pragma: no cover - runtime feedback
+        _log(f"{name} raised {exc!r}")
+
+
+def _wstring_from_ptr(pointer: int | None) -> str | None:
+    """Decode a pointer to a wide-character buffer returned by GWCA."""
+
+    if not pointer:
+        return None
+    try:
+        return ctypes.wstring_at(pointer)
+    except (ValueError, OSError):  # pragma: no cover - defensive path
+        return None
+
+
+_markup_pattern = re.compile(r"<[^>]+>")
+
+
+def _strip_markup(text: str) -> str:
+    """Remove Guild Wars formatting tags and control characters."""
+
+    if not text:
+        return ""
+    cleaned = _markup_pattern.sub("", text)
+    return "".join(
+        ch for ch in cleaned if ch in "\n\r\t" or ord(ch) >= 0x20
+    )
+
+
+def _decode_encoded_string(pointer: int | None) -> Optional[str]:
+    """Resolve an encoded Guild Wars string via ``UI::AsyncDecodeStr``."""
+
+    encoded = _wstring_from_ptr(pointer)
+    if not encoded:
+        return encoded
+
+    decoded_text: Optional[str] = None
+    completion = threading.Event()
+
+    def _on_decoded(_param, result: Optional[str]) -> None:
+        nonlocal decoded_text
+        decoded_text = result or ""
+        completion.set()
+
+    callback = _DecodeStrCallback(_on_decoded)
+    buffer = ctypes.create_unicode_buffer(encoded)
+    try:
+        _async_decode_str(buffer, callback, None, _DEFAULT_LANGUAGE)
+    except Exception:  # pragma: no cover - runtime fallback
+        return _strip_markup(encoded)
+
+    if not completion.wait(timeout=1.0):
+        return _strip_markup(encoded)
+    return _strip_markup(decoded_text or "")
+
+
+def _describe_log_state(log_state: int) -> str:
+    """Return a readable summary of quest flags stored in ``log_state``."""
+
+    flags: List[str] = []
+    if log_state & 0x2:
+        flags.append("completed")
+    if log_state & 0x10:
+        flags.append("mission quest")
+    if log_state & 0x40:
+        flags.append("area primary")
+    if log_state & 0x20:
+        flags.append("primary")
+    if not flags:
+        flags.append("active")
+    return ", ".join(flags)
+
+
+def _log_quest_details(quest: _QuestStruct) -> None:
+    """Pretty-print quest details obtained from ``GWCA::QuestMgr::GetQuest``."""
+
+    name = _decode_encoded_string(quest.name) or "<unnamed>"
+    location = _decode_encoded_string(quest.location) or "<unknown category>"
+    npc = _decode_encoded_string(quest.npc) or "<no giver>"
+    description = _decode_encoded_string(quest.description) or "<no description>"
+    objectives = _decode_encoded_string(quest.objectives) or "<no objectives>"
+    _log(f"Quest {quest.quest_id} – {name}")
+    _log(f"  Flags: {_describe_log_state(quest.log_state)}")
+    _log(f"  Category: {location}")
+    _log(f"  NPC: {npc}")
+    _log(
+        "  Marker: x={:.1f}, y={:.1f}, plane={:.1f}".format(
+            quest.marker.x, quest.marker.y, quest.marker.plane
+        )
+    )
+    _log(f"  Description: {description}")
+    _log(f"  Objectives: {objectives}")
+
+
+def draw_window() -> None:
+    """Render the ImGui window that exposes the quest helpers."""
+
+    global _quest_id_input
+    global _update_marker
+
+    if PyImGui.begin(MODULE_NAME):
+        PyImGui.text("Interact with quest exports provided by GWCA.dll")
+        PyImGui.separator()
+
+        _quest_id_input = PyImGui.input_int("Quest ID", _quest_id_input)
+        _update_marker = PyImGui.checkbox("Update quest marker", _update_marker)
+
+        if PyImGui.button("Get active quest (GWCA)"):
+            try:
+                quest_id = int(_get_active_quest_id().value)
+            except AttributeError:
+                quest_id = int(_get_active_quest_id())
+            _log(f"GWCA reports active quest ID: {quest_id}")
+
+        PyImGui.same_line(0.0, -1.0)
+        if PyImGui.button("Get active quest (PyQuest)"):
+            try:
+                quest_id = Quest.GetActiveQuest()
+            except Exception as exc:  # pragma: no cover - runtime feedback
+                _log(f"PyQuest.GetActiveQuest raised {exc!r}")
+            else:
+                _log(f"PyQuest reports active quest ID: {quest_id}")
+
+        if PyImGui.button("Set active quest (GWCA)"):
+            _call_bool("SetActiveQuestId", _set_active_quest_id, _quest_id_input)
+
+        PyImGui.same_line(0.0, -1.0)
+        if PyImGui.button("Set active quest (PyQuest)"):
+            try:
+                Quest.SetActiveQuest(_quest_id_input)
+            except Exception as exc:  # pragma: no cover - runtime feedback
+                _log(f"PyQuest.SetActiveQuest raised {exc!r}")
+            else:
+                _log("PyQuest.SetActiveQuest completed")
+
+        if PyImGui.button("Get quest details (GWCA)"):
+            try:
+                quest_ptr = _get_quest(_quest_id_input)
+            except Exception as exc:  # pragma: no cover - runtime feedback
+                _log(f"GetQuest raised {exc!r}")
+            else:
+                if not quest_ptr:
+                    _log("GetQuest returned NULL")
+                else:
+                    _log_quest_details(quest_ptr.contents)
+
+        if PyImGui.button("Request quest info (GWCA)"):
+            _call_bool(
+                "RequestQuestInfoId",
+                _request_quest_info,
+                _quest_id_input,
+                _update_marker,
+            )
+
+        PyImGui.same_line(0.0, -1.0)
+        if PyImGui.button("Request quest info (PyQuest)"):
+            try:
+                Quest.RequestQuestInfo(_quest_id_input, _update_marker)
+            except Exception as exc:  # pragma: no cover - runtime feedback
+                _log(f"PyQuest.RequestQuestInfo raised {exc!r}")
+            else:
+                _log("PyQuest.RequestQuestInfo completed")
+
+        if PyImGui.button("Abandon quest (GWCA)"):
+            _call_bool("AbandonQuestId", _abandon_quest_id, _quest_id_input)
+
+        PyImGui.same_line(0.0, -1.0)
+        if PyImGui.button("Abandon quest (PyQuest)"):
+            try:
+                Quest.AbandonQuest(_quest_id_input)
+            except Exception as exc:  # pragma: no cover - runtime feedback
+                _log(f"PyQuest.AbandonQuest raised {exc!r}")
+            else:
+                _log("PyQuest.AbandonQuest completed")
+
+        PyImGui.separator()
+        PyImGui.text("Recent calls:")
+        for entry in _logs:
+            PyImGui.bullet_text(entry)
+
+        PyImGui.end()
+
+
+def main() -> None:
+    try:
+        draw_window()
+    except Exception as exc:  # pragma: no cover - runtime feedback
+        Py4GW.Console.Log(MODULE_NAME, f"Unexpected error: {exc!r}")
+
+
+if __name__ == "__main__":
+    main()

--- a/Py4GWCoreLib/GWCA.py
+++ b/Py4GWCoreLib/GWCA.py
@@ -1,0 +1,162 @@
+"""Helpers for calling exported functions from GWCA.dll.
+
+This module offers a thin wrapper around :mod:`ctypes` so Py4GW scripts can
+bind decorated exports from ``GWCA.dll`` (the Guild Wars Client API library).
+The helpers only deal with obtaining the function pointer and applying the
+correct calling convention; scripts are still responsible for mapping the
+arguments and return types to matching ``ctypes`` declarations.
+"""
+from __future__ import annotations
+
+import ctypes
+from ctypes import c_bool, wintypes
+from typing import Optional, Sequence, Union
+
+__all__ = ["GWCALibrary", "load_gwca_function"]
+
+
+class GWCALibrary:
+    """Lightweight loader for ``GWCA.dll`` exports.
+
+    Parameters
+    ----------
+    module_name:
+        Name of the DLL to load. Defaults to ``"GWCA.dll"`` which is the
+        canonical name shipped with GWToolbox/Py4GW setups.
+    prefer_loaded:
+        If ``True`` (the default) and the module is already loaded inside the
+        current process the existing handle is reused. Reusing the handle avoids
+        accidentally loading a second copy of the library which would fail to
+        see Guild Wars' game state.
+    default_call_conv:
+        Either ``"cdecl"`` or ``"stdcall"``. GWCA exports are declared with
+        the default ``__cdecl`` calling convention, but the parameter is
+        exposed so that scripts can opt into ``stdcall`` when binding custom
+        hooks or third-party exports.
+    """
+
+    def __init__(
+        self,
+        module_name: str = "GWCA.dll",
+        *,
+        prefer_loaded: bool = True,
+        default_call_conv: str = "cdecl",
+    ) -> None:
+        self._module_name = module_name
+        self._kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        handle = wintypes.HMODULE()
+        if prefer_loaded:
+            existing = self._kernel32.GetModuleHandleW(module_name)
+            if existing:
+                handle = wintypes.HMODULE(existing)
+        if not handle.value:
+            # ``CDLL``/``WinDLL`` load the module if it is not already present.
+            self._cdecl = ctypes.CDLL(module_name)
+            self._stdcall = ctypes.WinDLL(module_name)
+            handle = wintypes.HMODULE(self._cdecl._handle)
+        else:
+            # Wrap the existing handle without reloading the DLL.
+            wrapped_handle = int(handle.value)
+            self._cdecl = ctypes.CDLL(module_name, handle=wrapped_handle)
+            self._stdcall = ctypes.WinDLL(module_name, handle=wrapped_handle)
+        self._handle = handle
+        self._default_call_conv = default_call_conv.lower()
+        self._initialized = False
+
+        if not self.initialize():
+            raise RuntimeError("GWCA::Initialize() failed")
+
+    @property
+    def handle(self) -> int:
+        """Return the raw ``HMODULE`` handle."""
+
+        return self._handle.value
+
+    def initialize(self) -> bool:
+        """Ensure ``GWCA::Initialize`` ran successfully."""
+
+        if not self._initialized:
+            initialize = self.get_function(
+                "?Initialize@GW@@YA_NXZ", restype=c_bool
+            )
+            self._initialized = bool(initialize())
+        return self._initialized
+
+    def get_function(
+        self,
+        symbol: Union[str, int],
+        *,
+        restype: Optional[ctypes._CData] = None,
+        argtypes: Sequence[ctypes._CData] | None = None,
+        call_conv: Optional[str] = None,
+    ) -> ctypes._CFuncPtr:
+        """Return a callable ctypes wrapper for an exported function.
+
+        Parameters
+        ----------
+        symbol:
+            Either the decorated export name (for example,
+            ``"?GetMapID@Map@GW@@YA?AW4MapID@Constants@2@XZ"``) or the ordinal
+            number published by the DLL (``193`` for ``GetMapID`` in the list
+            provided by GWCA).
+        restype:
+            ``ctypes`` type that describes the function's return value. ``None``
+            (the default) makes the wrapper behave like a ``void`` function.
+        argtypes:
+            Sequence describing the argument types for ``ctypes``. Providing it
+            enables automatic type conversion and stack validation.
+        call_conv:
+            Override for the calling convention. ``"cdecl"`` uses the ``CDLL``
+            binding while ``"stdcall"`` uses the ``WinDLL`` binding.
+
+        Returns
+        -------
+        ``ctypes._CFuncPtr``
+            A ready-to-use callable that can be invoked directly from Python.
+        """
+
+        binding = (call_conv or self._default_call_conv).lower()
+        if binding not in {"cdecl", "stdcall"}:
+            raise ValueError("call_conv must be either 'cdecl' or 'stdcall'")
+
+        library = self._cdecl if binding == "cdecl" else self._stdcall
+        if isinstance(symbol, int):
+            lookup = f"#{symbol}"
+        else:
+            lookup = symbol
+        try:
+            func = getattr(library, lookup)
+        except AttributeError as exc:  # pragma: no cover - defensive path
+            raise AttributeError(
+                f"Function '{symbol}' not found in {self._module_name}"
+            ) from exc
+
+        if argtypes is not None:
+            func.argtypes = list(argtypes)
+        if restype is not None:
+            func.restype = restype
+        return func
+
+
+def load_gwca_function(
+    symbol: Union[str, int],
+    *,
+    restype: Optional[ctypes._CData] = None,
+    argtypes: Sequence[ctypes._CData] | None = None,
+    call_conv: str = "cdecl",
+    module_name: str = "GWCA.dll",
+    prefer_loaded: bool = True,
+) -> ctypes._CFuncPtr:
+    """Convenience wrapper that instantiates :class:`GWCALibrary` on demand."""
+
+    library = GWCALibrary(
+        module_name=module_name,
+        prefer_loaded=prefer_loaded,
+        default_call_conv=call_conv,
+    )
+    return library.get_function(
+        symbol,
+        restype=restype,
+        argtypes=argtypes,
+        call_conv=call_conv,
+    )

--- a/Py4GWCoreLib/__init__.py
+++ b/Py4GWCoreLib/__init__.py
@@ -46,6 +46,7 @@ from .Effect import *
 from .Merchant import *
 from .Quest import *
 from .Camera import *
+from .GWCA import GWCALibrary, load_gwca_function
 
 from .Py4GWcorelib import *
 from .Overlay import *

--- a/docs/gwca_function_calls.md
+++ b/docs/gwca_function_calls.md
@@ -1,0 +1,143 @@
+# Calling functions exported by `GWCA.dll`
+
+When the Guild Wars client has `GWCA.dll` injected you can call any of its
+exports from a Py4GW script.  The new `Py4GWCoreLib.GWCA` helper removes the
+boilerplate usually required to bind decorated C++ exports with `ctypes`.
+
+## 1. Load the library and call `Initialize`
+
+```python
+from Py4GWCoreLib import GWCALibrary
+
+gwca = GWCALibrary()  # reuses the already-injected module inside Guild Wars
+gwca.initialize()     # ensures GWCA scanned memory and installed its hooks
+```
+
+`GWCALibrary` looks for an existing copy of the DLL inside the game process
+and reuses that handle so you are always talking to the injected module rather
+than loading a new copy.【F:Py4GWCoreLib/GWCA.py†L41-L57】  During construction it
+invokes `GWCA::Initialize` and raises an error if the call fails, but invoking
+`initialize()` explicitly at the start of your script makes the dependency
+obvious and lets you retry in custom workflows.【F:Py4GWCoreLib/GWCA.py†L59-L80】
+
+If you only need a single function you can skip the explicit instance and call
+`load_gwca_function(...)` instead, which internally constructs a
+`GWCALibrary` and returns the bound callable.【F:Py4GWCoreLib/GWCA.py†L102-L118】
+
+## 2. Bind the function you need
+
+Pass either the decorated export name or the ordinal from your dump together
+with the expected signature:
+
+```python
+from ctypes import c_bool, c_uint32
+
+# Using the decorated name
+destroy_item = gwca.get_function(
+    "?DestroyItem@Items@GW@@YA_NI@Z",
+    restype=c_bool,
+    argtypes=(c_uint32,),
+)
+
+# Using the ordinal number (466 == UseSkill in the table you provided)
+use_skill = gwca.get_function(
+    466,
+    restype=c_bool,
+    argtypes=(c_uint32, c_uint32),
+)
+```
+
+The helper accepts either `cdecl` (GWCA’s default) or `stdcall` bindings and
+exposes them via the `call_conv` parameter when needed.【F:Py4GWCoreLib/GWCA.py†L59-L100】
+
+## 3. Call the function inside your script
+
+```python
+item_id = 0x12345678
+if destroy_item(item_id):
+    print(f"Destroyed item {item_id:#x}")
+
+skill_id = 5
+current_target = 0  # use 0 to keep the current target
+gwca.Console.Log("demo", f"Use skill {skill_id}")
+use_skill(skill_id, current_target)
+```
+
+Because the return value and parameter types are backed by `ctypes`, Python
+will automatically marshal integral values for you. For pointers or structures
+create the corresponding `ctypes` definitions before binding the function. For
+example, the quest demo maps `GW::Quest` and its nested `GW::GamePos` before
+calling `GW::QuestMgr::GetQuest`:
+
+```python
+import ctypes
+import threading
+from ctypes import POINTER, Structure, c_float, c_uint32, c_void_p
+
+
+class GamePos(Structure):
+    _fields_ = [
+        ("x", c_float),
+        ("y", c_float),
+        ("plane", c_float),
+    ]
+
+
+class QuestStruct(Structure):
+    _fields_ = [
+        ("quest_id", c_uint32),
+        ("log_state", c_uint32),
+        ("location", c_void_p),
+        ("name", c_void_p),
+        ("npc", c_void_p),
+        ("map_from", c_uint32),
+        ("marker", GamePos),
+        ("_unknown_0x24", c_uint32),
+        ("map_to", c_uint32),
+        ("description", c_void_p),
+        ("objectives", c_void_p),
+    ]
+
+
+get_quest = gwca.get_function(
+    "?GetQuest@QuestMgr@GW@@YAPAUQuest@2@W4QuestID@Constants@2@@Z",
+    restype=POINTER(QuestStruct),
+    argtypes=(c_uint32,),
+)
+quest_ptr = get_quest(quest_id)
+if quest_ptr:
+    quest = quest_ptr.contents
+    encoded_name = ctypes.wstring_at(quest.name) if quest.name else None
+
+# Quest strings are encoded; decode them with UI::AsyncDecodeStr before displaying.
+if encoded_name:
+    callback_type = ctypes.CFUNCTYPE(None, ctypes.c_void_p, ctypes.c_wchar_p)
+    decoded_name = {"value": ""}
+    done = threading.Event()
+
+    def _on_decoded(_param, text):
+        decoded_name["value"] = text or ""
+        done.set()
+
+    async_decode = gwca.get_function(
+        "?AsyncDecodeStr@UI@GW@@YAXPB_WP6AXPAX0@Z1W4Language@Constants@2@@Z",
+        argtypes=(ctypes.c_wchar_p, callback_type, ctypes.c_void_p, ctypes.c_uint32),
+    )
+    callback = callback_type(_on_decoded)
+    buffer = ctypes.create_unicode_buffer(encoded_name)
+    async_decode(buffer, callback, None, 0xFF)
+    done.wait(timeout=1.0)
+    quest_name = decoded_name["value"]
+```
+
+## Tips
+
+* Keep using the Py4GW helper APIs (agents, inventory, etc.) whenever they
+  already expose the behaviour you need. Drop down to `GWCA.dll` only for
+  features that have not been wrapped yet.
+* Many GWCA exports expect to be executed on the Guild Wars game thread. Use
+  the existing `GameThread` utilities from Py4GW when you need to enqueue work
+  there before calling into GWCA.
+* Invalid signatures or incorrect calling conventions typically crash the
+  Guild Wars client. Double-check the parameters against the GWCA headers in
+  `external/GWToolboxpp/Dependencies/GWCA/include` when in doubt.


### PR DESCRIPTION
## Summary
- decode quest log strings by invoking GW::UI::AsyncDecodeStr and stripping Guild Wars markup before logging in the demo
- document the AsyncDecodeStr workflow so scripts can resolve encoded GWCA strings safely

## Testing
- python -m compileall DEMO/DEMO_GWCA_Quest_Demo.py Py4GWCoreLib/GWCA.py

------
https://chatgpt.com/codex/tasks/task_e_68dd7eae92e8832ebe430705240ccd4d