### PR TITLE
Decode GWCA quest strings via AsyncDecodeStr

### DIFF
--- a/DEMO/DEMO_GWCA_Quest_Demo.py
+++ b/DEMO/DEMO_GWCA_Quest_Demo.py
@@ -1,0 +1,276 @@
+"""Interactive demo for quest-related GWCA exports.
+
+This script showcases how to call quest functions exposed by ``gwca.dll``
+through the :class:`Py4GWCoreLib.GWCA.GWCALibrary` helper.  Launch it from
+Py4GW while the Guild Wars client is running with GWCA injected to experiment
+with setting, requesting and abandoning quests directly from the DLL.
+"""
+from __future__ import annotations
+
+from ctypes import POINTER, Structure, c_bool, c_float, c_uint32, c_void_p
+from typing import List
+
+import ctypes
+import Py4GW
+import PyImGui
+
+from Py4GWCoreLib import EncodedStringDecoder, get_shared_gwca_library
+from Py4GWCoreLib.Quest import Quest
+
+MODULE_NAME = "GWCA Quest Demo"
+
+_gwca = get_shared_gwca_library()
+_gwca.initialize()
+_string_decoder = EncodedStringDecoder(_gwca, timeout=0.5)
+
+
+class _GamePos(Structure):
+    """Representation of ``GW::GamePos`` used inside ``GW::Quest``."""
+
+    _fields_ = [
+        ("x", c_float),
+        ("y", c_float),
+        ("plane", c_float),
+    ]
+
+
+class _QuestStruct(Structure):
+    """Mirror of the ``GW::Quest`` structure returned by ``GetQuest``."""
+
+    _fields_ = [
+        ("quest_id", c_uint32),
+        ("log_state", c_uint32),
+        ("location", c_void_p),
+        ("name", c_void_p),
+        ("npc", c_void_p),
+        ("map_from", c_uint32),
+        ("marker", _GamePos),
+        ("_unknown_0x24", c_uint32),
+        ("map_to", c_uint32),
+        ("description", c_void_p),
+        ("objectives", c_void_p),
+    ]
+
+
+_get_active_quest_id = _gwca.get_function(
+    "?GetActiveQuestId@QuestMgr@GW@@YA?AW4QuestID@Constants@2@XZ",
+    restype=c_uint32,
+)
+_set_active_quest_id = _gwca.get_function(
+    "?SetActiveQuestId@QuestMgr@GW@@YA_NW4QuestID@Constants@2@@Z",
+    restype=c_bool,
+    argtypes=(c_uint32,),
+)
+_abandon_quest_id = _gwca.get_function(
+    "?AbandonQuestId@QuestMgr@GW@@YA_NW4QuestID@Constants@2@@Z",
+    restype=c_bool,
+    argtypes=(c_uint32,),
+)
+_request_quest_info = _gwca.get_function(
+    "?RequestQuestInfoId@QuestMgr@GW@@YA_NW4QuestID@Constants@2@_N@Z",
+    restype=c_bool,
+    argtypes=(c_uint32, c_bool),
+)
+_get_quest = _gwca.get_function(
+    "?GetQuest@QuestMgr@GW@@YAPAUQuest@2@W4QuestID@Constants@2@@Z",
+    restype=POINTER(_QuestStruct),
+    argtypes=(c_uint32,),
+)
+
+_quest_id_input = 0
+_update_marker = False
+_logs: List[str] = []
+
+
+def _sanitize_console_text(text: str) -> str:
+    """Replace unsupported surrogate code points before logging."""
+
+    sanitized_chars = []
+    for char in text:
+        codepoint = ord(char)
+        if 0xD800 <= codepoint <= 0xDFFF:
+            sanitized_chars.append("?")
+        else:
+            sanitized_chars.append(char)
+    return "".join(sanitized_chars)
+
+
+def _log(message: str) -> None:
+    """Send a message to both the Py4GW console and the ImGui log view."""
+
+    safe_message = _sanitize_console_text(message)
+    Py4GW.Console.Log(MODULE_NAME, safe_message)
+    _logs.append(safe_message)
+    if len(_logs) > 12:
+        del _logs[0]
+
+
+def _call_bool(name: str, func, *args) -> None:
+    """Call a GWCA function and record its success state."""
+
+    try:
+        success = bool(func(*args))
+        status = "succeeded" if success else "failed"
+        _log(f"{name} {status}")
+    except Exception as exc:  # pragma: no cover - runtime feedback
+        _log(f"{name} raised {exc!r}")
+
+
+def _decode_encoded_fields(*pointers: int | None) -> List[str | None]:
+    """Resolve encoded quest strings through ``GW::UI::AsyncDecodeStr``."""
+
+    decoded_values = _string_decoder.decode_many(list(pointers))
+    results: List[str | None] = []
+    for pointer, decoded in zip(pointers, decoded_values):
+        if decoded is None and pointer:
+            try:
+                decoded = ctypes.wstring_at(pointer)
+            except (ValueError, OSError):  # pragma: no cover - defensive path
+                decoded = None
+        results.append(decoded)
+    return results
+
+
+def _describe_log_state(log_state: int) -> str:
+    """Return a readable summary of quest flags stored in ``log_state``."""
+
+    flags: List[str] = []
+    if log_state & 0x2:
+        flags.append("completed")
+    if log_state & 0x10:
+        flags.append("mission quest")
+    if log_state & 0x40:
+        flags.append("area primary")
+    if log_state & 0x20:
+        flags.append("primary")
+    if not flags:
+        flags.append("active")
+    return ", ".join(flags)
+
+
+def _log_quest_details(quest: _QuestStruct) -> None:
+    """Pretty-print quest details obtained from ``GWCA::QuestMgr::GetQuest``."""
+
+    name, location, npc, description, objectives = _decode_encoded_fields(
+        int(quest.name) if quest.name else None,
+        int(quest.location) if quest.location else None,
+        int(quest.npc) if quest.npc else None,
+        int(quest.description) if quest.description else None,
+        int(quest.objectives) if quest.objectives else None,
+    )
+    name = name or "<unnamed>"
+    location = location or "<unknown category>"
+    npc = npc or "<no giver>"
+    description = description or "<no description>"
+    objectives = objectives or "<no objectives>"
+    _log(f"Quest {quest.quest_id} – {name}")
+    _log(f"  Flags: {_describe_log_state(quest.log_state)}")
+    _log(f"  Category: {location}")
+    _log(f"  NPC: {npc}")
+    _log(
+        "  Marker: x={:.1f}, y={:.1f}, plane={:.1f}".format(
+            quest.marker.x, quest.marker.y, quest.marker.plane
+        )
+    )
+    _log(f"  Description: {description}")
+    _log(f"  Objectives: {objectives}")
+
+
+def draw_window() -> None:
+    """Render the ImGui window that exposes the quest helpers."""
+
+    global _quest_id_input
+    global _update_marker
+
+    if PyImGui.begin(MODULE_NAME):
+        PyImGui.text("Interact with quest exports provided by gwca.dll")
+        PyImGui.separator()
+
+        _quest_id_input = PyImGui.input_int("Quest ID", _quest_id_input)
+        _update_marker = PyImGui.checkbox("Update quest marker", _update_marker)
+
+        if PyImGui.button("Get active quest (GWCA)"):
+            try:
+                quest_id = int(_get_active_quest_id().value)
+            except AttributeError:
+                quest_id = int(_get_active_quest_id())
+            _log(f"GWCA reports active quest ID: {quest_id}")
+
+        PyImGui.same_line(0.0, -1.0)
+        if PyImGui.button("Get active quest (PyQuest)"):
+            try:
+                quest_id = Quest.GetActiveQuest()
+            except Exception as exc:  # pragma: no cover - runtime feedback
+                _log(f"PyQuest.GetActiveQuest raised {exc!r}")
+            else:
+                _log(f"PyQuest reports active quest ID: {quest_id}")
+
+        if PyImGui.button("Set active quest (GWCA)"):
+            _call_bool("SetActiveQuestId", _set_active_quest_id, _quest_id_input)
+
+        PyImGui.same_line(0.0, -1.0)
+        if PyImGui.button("Set active quest (PyQuest)"):
+            try:
+                Quest.SetActiveQuest(_quest_id_input)
+            except Exception as exc:  # pragma: no cover - runtime feedback
+                _log(f"PyQuest.SetActiveQuest raised {exc!r}")
+            else:
+                _log("PyQuest.SetActiveQuest completed")
+
+        if PyImGui.button("Get quest details (GWCA)"):
+            try:
+                quest_ptr = _get_quest(_quest_id_input)
+            except Exception as exc:  # pragma: no cover - runtime feedback
+                _log(f"GetQuest raised {exc!r}")
+            else:
+                if not quest_ptr:
+                    _log("GetQuest returned NULL")
+                else:
+                    _log_quest_details(quest_ptr.contents)
+
+        if PyImGui.button("Request quest info (GWCA)"):
+            _call_bool(
+                "RequestQuestInfoId",
+                _request_quest_info,
+                _quest_id_input,
+                _update_marker,
+            )
+
+        PyImGui.same_line(0.0, -1.0)
+        if PyImGui.button("Request quest info (PyQuest)"):
+            try:
+                Quest.RequestQuestInfo(_quest_id_input, _update_marker)
+            except Exception as exc:  # pragma: no cover - runtime feedback
+                _log(f"PyQuest.RequestQuestInfo raised {exc!r}")
+            else:
+                _log("PyQuest.RequestQuestInfo completed")
+
+        if PyImGui.button("Abandon quest (GWCA)"):
+            _call_bool("AbandonQuestId", _abandon_quest_id, _quest_id_input)
+
+        PyImGui.same_line(0.0, -1.0)
+        if PyImGui.button("Abandon quest (PyQuest)"):
+            try:
+                Quest.AbandonQuest(_quest_id_input)
+            except Exception as exc:  # pragma: no cover - runtime feedback
+                _log(f"PyQuest.AbandonQuest raised {exc!r}")
+            else:
+                _log("PyQuest.AbandonQuest completed")
+
+        PyImGui.separator()
+        PyImGui.text("Recent calls:")
+        for entry in _logs:
+            PyImGui.bullet_text(entry)
+
+        PyImGui.end()
+
+
+def main() -> None:
+    try:
+        draw_window()
+    except Exception as exc:  # pragma: no cover - runtime feedback
+        Py4GW.Console.Log(MODULE_NAME, f"Unexpected error: {exc!r}")
+
+
+if __name__ == "__main__":
+    main()

--- a/Py4GWCoreLib/GWCA.py
+++ b/Py4GWCoreLib/GWCA.py
@@ -260,13 +260,25 @@ class GWCALibrary:
                 if module_base:
                     candidate_names.append(module_base)
 
-                normalized = {
-                    name.lower()
-                    for name in candidate_names
-                    if name
-                }
-                if normalized & targets:
-                    return int(handle), module_path
+                normalized = [name.lower() for name in candidate_names if name]
+                if not normalized:
+                    continue
+
+                for name in normalized:
+                    for target in targets:
+                        if name == target or name.endswith(target):
+                            return int(handle), module_path
+
+                if stem:
+                    stem_lower = stem.lower()
+                    for name in candidate_names:
+                        if not name:
+                            continue
+                        try:
+                            if Path(name).stem.lower() == stem_lower:
+                                return int(handle), module_path
+                        except Exception:  # pragma: no cover - defensive
+                            continue
         return None, None
 
     def _get_module_path(

--- a/Py4GWCoreLib/GWCA.py
+++ b/Py4GWCoreLib/GWCA.py
@@ -277,9 +277,14 @@ class GWCALibrary:
                 if module_base:
                     candidate_names.append(module_base)
 
-                normalized = [name.lower() for name in candidate_names if name]
-                if not normalized:
-                    continue
+                normalized: list[str] = []
+                for name in candidate_names:
+                    if not name:
+                        continue
+                    try:
+                        normalized.append(str(name).lower())
+                    except Exception:  # pragma: no cover - defensive
+                        continue
 
                 for name in normalized:
                     for target in targets:
@@ -292,10 +297,20 @@ class GWCALibrary:
                         if not name:
                             continue
                         try:
-                            if Path(name).stem.lower() == stem_lower:
+                            if Path(str(name)).stem.lower() == stem_lower:
                                 return int(handle), module_path
                         except Exception:  # pragma: no cover - defensive
                             continue
+
+                # As a final fallback, probe for a well-known export on the
+                # module handle in case the DLL was renamed during injection.
+                try:
+                    probe = _WinDLLNoFree(None, handle=int(handle))
+                    getattr(probe, "GWCAVersion")
+                except (AttributeError, OSError, ValueError):
+                    continue
+                else:
+                    return int(handle), module_path
         return None, None
 
     def _get_module_path(

--- a/Py4GWCoreLib/GWCA.py
+++ b/Py4GWCoreLib/GWCA.py
@@ -80,6 +80,19 @@ class GWCALibrary:
             wintypes.DWORD,
         ]
         self._kernel32.GetModuleFileNameW.restype = wintypes.DWORD
+        self._kernel32.GetCurrentProcess.restype = wintypes.HANDLE
+        try:
+            self._psapi = ctypes.WinDLL("psapi", use_last_error=True)
+        except OSError:  # pragma: no cover - psapi should always be present on Windows
+            self._psapi = None
+        else:
+            self._psapi.EnumProcessModules.argtypes = [
+                wintypes.HANDLE,
+                ctypes.POINTER(wintypes.HMODULE),
+                wintypes.DWORD,
+                ctypes.POINTER(wintypes.DWORD),
+            ]
+            self._psapi.EnumProcessModules.restype = wintypes.BOOL
 
         handle_value: Optional[int] = None
 
@@ -204,8 +217,18 @@ class GWCALibrary:
         """Return an existing module handle and its on-disk path if available."""
 
         candidates: list[str] = []
-        base = Path(module_name).name
-        for name in (module_name, base, base.lower(), base.upper()):
+        path = Path(module_name)
+        base = path.name
+        stem = path.stem or base
+        for name in (
+            module_name,
+            base,
+            base.lower(),
+            base.upper(),
+            stem,
+            stem.lower(),
+            stem.upper(),
+        ):
             if name and name not in candidates:
                 candidates.append(name)
 
@@ -215,6 +238,15 @@ class GWCALibrary:
                 win_handle = wintypes.HMODULE(handle)
                 path = self._get_module_path(win_handle)
                 return int(win_handle.value), path
+
+        enumerated = self._enumerate_process_modules()
+        if enumerated:
+            target = base.lower()
+            for handle, module_path in enumerated:
+                if not module_path:
+                    continue
+                if Path(module_path).name.lower() == target:
+                    return int(handle.value), module_path
         return None, None
 
     def _get_module_path(self, handle: wintypes.HMODULE) -> Optional[str]:
@@ -229,6 +261,44 @@ class GWCALibrary:
             if written < buffer_length - 1:
                 return buffer.value
             buffer_length *= 2
+
+    def _enumerate_process_modules(self) -> list[tuple[wintypes.HMODULE, Optional[str]]]:
+        """Return a list of modules loaded in the current process."""
+
+        if self._psapi is None:
+            return []
+
+        capacity = 32
+        process = self._kernel32.GetCurrentProcess()
+        needed = wintypes.DWORD()
+        modules: list[tuple[wintypes.HMODULE, Optional[str]]] = []
+        module_size = ctypes.sizeof(wintypes.HMODULE)
+
+        while True:
+            array_type = wintypes.HMODULE * capacity
+            module_array = array_type()
+            buffer_size = ctypes.sizeof(module_array)
+            if not self._psapi.EnumProcessModules(
+                process,
+                module_array,
+                buffer_size,
+                ctypes.byref(needed),
+            ):
+                return []
+
+            module_count = needed.value // module_size
+            if module_count <= capacity:
+                for index in range(module_count):
+                    handle_value = module_array[index].value
+                    if not handle_value:
+                        continue
+                    module_handle = wintypes.HMODULE(handle_value)
+                    modules.append(
+                        (module_handle, self._get_module_path(module_handle))
+                    )
+                return modules
+
+            capacity = module_count + 8
 
 
 class EncodedStringDecoder:

--- a/Py4GWCoreLib/GWCA.py
+++ b/Py4GWCoreLib/GWCA.py
@@ -93,6 +93,13 @@ class GWCALibrary:
                 ctypes.POINTER(wintypes.DWORD),
             ]
             self._psapi.EnumProcessModules.restype = wintypes.BOOL
+            self._psapi.GetModuleBaseNameW.argtypes = [
+                wintypes.HANDLE,
+                wintypes.HMODULE,
+                wintypes.LPWSTR,
+                wintypes.DWORD,
+            ]
+            self._psapi.GetModuleBaseNameW.restype = wintypes.DWORD
 
         handle_value: Optional[int] = None
 
@@ -241,11 +248,24 @@ class GWCALibrary:
 
         enumerated = self._enumerate_process_modules()
         if enumerated:
-            target = base.lower()
-            for handle, module_path in enumerated:
-                if not module_path:
-                    continue
-                if Path(module_path).name.lower() == target:
+            targets = {base.lower()}
+            if stem:
+                targets.add(stem.lower())
+
+            for handle, module_path, module_base in enumerated:
+                candidate_names: list[str] = []
+                if module_path:
+                    candidate_names.append(Path(module_path).name)
+                    candidate_names.append(module_path)
+                if module_base:
+                    candidate_names.append(module_base)
+
+                normalized = {
+                    name.lower()
+                    for name in candidate_names
+                    if name
+                }
+                if normalized & targets:
                     return int(handle), module_path
         return None, None
 
@@ -267,7 +287,7 @@ class GWCALibrary:
                 return buffer.value
             buffer_length *= 2
 
-    def _enumerate_process_modules(self) -> list[tuple[int, Optional[str]]]:
+    def _enumerate_process_modules(self) -> list[tuple[int, Optional[str], Optional[str]]]:
         """Return a list of modules loaded in the current process."""
 
         if self._psapi is None:
@@ -276,7 +296,7 @@ class GWCALibrary:
         capacity = 32
         process = self._kernel32.GetCurrentProcess()
         needed = wintypes.DWORD()
-        modules: list[tuple[int, Optional[str]]] = []
+        modules: list[tuple[int, Optional[str], Optional[str]]] = []
         module_size = ctypes.sizeof(wintypes.HMODULE)
 
         while True:
@@ -300,11 +320,42 @@ class GWCALibrary:
                     if handle_value == 0:
                         continue
                     modules.append(
-                        (handle_value, self._get_module_path(handle_value))
+                        (
+                            handle_value,
+                            self._get_module_path(handle_value),
+                            self._get_module_base_name(handle_value),
+                        )
                     )
                 return modules
 
             capacity = module_count + 8
+
+    def _get_module_base_name(
+        self, handle: Union[int, wintypes.HMODULE]
+    ) -> Optional[str]:
+        """Return the base filename for a module handle."""
+
+        if self._psapi is None:
+            return None
+
+        if isinstance(handle, int):
+            handle = wintypes.HMODULE(handle)
+
+        process = self._kernel32.GetCurrentProcess()
+        buffer_length = 260
+        while True:
+            buffer = ctypes.create_unicode_buffer(buffer_length)
+            written = self._psapi.GetModuleBaseNameW(
+                process,
+                handle,
+                buffer,
+                buffer_length,
+            )
+            if written == 0:
+                return None
+            if written < buffer_length - 1:
+                return buffer.value
+            buffer_length *= 2
 
 
 class EncodedStringDecoder:

--- a/Py4GWCoreLib/GWCA.py
+++ b/Py4GWCoreLib/GWCA.py
@@ -81,6 +81,14 @@ class GWCALibrary:
         ]
         self._kernel32.GetModuleFileNameW.restype = wintypes.DWORD
         self._kernel32.GetCurrentProcess.restype = wintypes.HANDLE
+        self._kernel32.GetCurrentProcessId.restype = wintypes.DWORD
+        self._kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+        self._kernel32.CloseHandle.restype = wintypes.BOOL
+        self._kernel32.CreateToolhelp32Snapshot.argtypes = [
+            wintypes.DWORD,
+            wintypes.DWORD,
+        ]
+        self._kernel32.CreateToolhelp32Snapshot.restype = wintypes.HANDLE
         try:
             self._psapi = ctypes.WinDLL("psapi", use_last_error=True)
         except OSError:  # pragma: no cover - psapi should always be present on Windows
@@ -93,6 +101,15 @@ class GWCALibrary:
                 ctypes.POINTER(wintypes.DWORD),
             ]
             self._psapi.EnumProcessModules.restype = wintypes.BOOL
+            if hasattr(self._psapi, "EnumProcessModulesEx"):
+                self._psapi.EnumProcessModulesEx.argtypes = [
+                    wintypes.HANDLE,
+                    ctypes.POINTER(wintypes.HMODULE),
+                    wintypes.DWORD,
+                    ctypes.POINTER(wintypes.DWORD),
+                    wintypes.DWORD,
+                ]
+                self._psapi.EnumProcessModulesEx.restype = wintypes.BOOL
             self._psapi.GetModuleBaseNameW.argtypes = [
                 wintypes.HANDLE,
                 wintypes.HMODULE,
@@ -302,6 +319,14 @@ class GWCALibrary:
     def _enumerate_process_modules(self) -> list[tuple[int, Optional[str], Optional[str]]]:
         """Return a list of modules loaded in the current process."""
 
+        modules = self._enumerate_process_modules_psapi()
+        if modules:
+            return modules
+        return self._enumerate_process_modules_toolhelp()
+
+    def _enumerate_process_modules_psapi(
+        self,
+    ) -> list[tuple[int, Optional[str], Optional[str]]]:
         if self._psapi is None:
             return []
 
@@ -311,16 +336,28 @@ class GWCALibrary:
         modules: list[tuple[int, Optional[str], Optional[str]]] = []
         module_size = ctypes.sizeof(wintypes.HMODULE)
 
+        enum_func = getattr(self._psapi, "EnumProcessModulesEx", None)
+        enum_flags = 0x03  # LIST_MODULES_ALL
         while True:
             array_type = wintypes.HMODULE * capacity
             module_array = array_type()
             buffer_size = ctypes.sizeof(module_array)
-            if not self._psapi.EnumProcessModules(
-                process,
-                module_array,
-                buffer_size,
-                ctypes.byref(needed),
-            ):
+            if enum_func is None:
+                ok = self._psapi.EnumProcessModules(
+                    process,
+                    module_array,
+                    buffer_size,
+                    ctypes.byref(needed),
+                )
+            else:
+                ok = enum_func(
+                    process,
+                    module_array,
+                    buffer_size,
+                    ctypes.byref(needed),
+                    enum_flags,
+                )
+            if not ok:
                 return []
 
             required_bytes = needed.value
@@ -341,6 +378,65 @@ class GWCALibrary:
                 return modules
 
             capacity = module_count + 8
+
+    def _enumerate_process_modules_toolhelp(
+        self,
+    ) -> list[tuple[int, Optional[str], Optional[str]]]:
+        TH32CS_SNAPMODULE = 0x00000008
+        TH32CS_SNAPMODULE32 = 0x00000010
+        INVALID_HANDLE_VALUE = wintypes.HANDLE(-1).value
+
+        class MODULEENTRY32W(ctypes.Structure):
+            _fields_ = [
+                ("dwSize", wintypes.DWORD),
+                ("th32ModuleID", wintypes.DWORD),
+                ("th32ProcessID", wintypes.DWORD),
+                ("GlblcntUsage", wintypes.DWORD),
+                ("ProccntUsage", wintypes.DWORD),
+                ("modBaseAddr", ctypes.POINTER(ctypes.c_byte)),
+                ("modBaseSize", wintypes.DWORD),
+                ("hModule", wintypes.HMODULE),
+                ("szModule", wintypes.WCHAR * 256),
+                ("szExePath", wintypes.WCHAR * 260),
+            ]
+
+        self._kernel32.Module32FirstW.argtypes = [
+            wintypes.HANDLE,
+            ctypes.POINTER(MODULEENTRY32W),
+        ]
+        self._kernel32.Module32FirstW.restype = wintypes.BOOL
+        self._kernel32.Module32NextW.argtypes = [
+            wintypes.HANDLE,
+            ctypes.POINTER(MODULEENTRY32W),
+        ]
+        self._kernel32.Module32NextW.restype = wintypes.BOOL
+
+        snapshot = self._kernel32.CreateToolhelp32Snapshot(
+            TH32CS_SNAPMODULE | TH32CS_SNAPMODULE32,
+            self._kernel32.GetCurrentProcessId(),
+        )
+        if snapshot == INVALID_HANDLE_VALUE:
+            return []
+
+        modules: list[tuple[int, Optional[str], Optional[str]]] = []
+        entry = MODULEENTRY32W()
+        entry.dwSize = ctypes.sizeof(MODULEENTRY32W)
+
+        try:
+            if not self._kernel32.Module32FirstW(snapshot, ctypes.byref(entry)):
+                return []
+            while True:
+                handle_value = int(entry.hModule)
+                if handle_value:
+                    path = entry.szExePath or None
+                    base = entry.szModule or None
+                    modules.append((handle_value, path, base))
+                if not self._kernel32.Module32NextW(snapshot, ctypes.byref(entry)):
+                    break
+        finally:
+            self._kernel32.CloseHandle(snapshot)
+
+        return modules
 
     def _get_module_base_name(
         self, handle: Union[int, wintypes.HMODULE]

--- a/Py4GWCoreLib/GWCA.py
+++ b/Py4GWCoreLib/GWCA.py
@@ -246,11 +246,16 @@ class GWCALibrary:
                 if not module_path:
                     continue
                 if Path(module_path).name.lower() == target:
-                    return int(handle.value), module_path
+                    return int(handle), module_path
         return None, None
 
-    def _get_module_path(self, handle: wintypes.HMODULE) -> Optional[str]:
+    def _get_module_path(
+        self, handle: Union[int, wintypes.HMODULE]
+    ) -> Optional[str]:
         """Resolve the filesystem path for a loaded module handle."""
+
+        if isinstance(handle, int):
+            handle = wintypes.HMODULE(handle)
 
         buffer_length = 260
         while True:
@@ -262,7 +267,7 @@ class GWCALibrary:
                 return buffer.value
             buffer_length *= 2
 
-    def _enumerate_process_modules(self) -> list[tuple[wintypes.HMODULE, Optional[str]]]:
+    def _enumerate_process_modules(self) -> list[tuple[int, Optional[str]]]:
         """Return a list of modules loaded in the current process."""
 
         if self._psapi is None:
@@ -271,7 +276,7 @@ class GWCALibrary:
         capacity = 32
         process = self._kernel32.GetCurrentProcess()
         needed = wintypes.DWORD()
-        modules: list[tuple[wintypes.HMODULE, Optional[str]]] = []
+        modules: list[tuple[int, Optional[str]]] = []
         module_size = ctypes.sizeof(wintypes.HMODULE)
 
         while True:
@@ -286,15 +291,16 @@ class GWCALibrary:
             ):
                 return []
 
-            module_count = needed.value // module_size
-            if module_count <= capacity:
+            required_bytes = needed.value
+            module_count = required_bytes // module_size
+            if required_bytes <= buffer_size:
                 for index in range(module_count):
-                    handle_value = module_array[index].value
-                    if not handle_value:
+                    raw_handle = module_array[index]
+                    handle_value = int(raw_handle)
+                    if handle_value == 0:
                         continue
-                    module_handle = wintypes.HMODULE(handle_value)
                     modules.append(
-                        (module_handle, self._get_module_path(module_handle))
+                        (handle_value, self._get_module_path(handle_value))
                     )
                 return modules
 

--- a/Py4GWCoreLib/GWCA.py
+++ b/Py4GWCoreLib/GWCA.py
@@ -1,0 +1,353 @@
+"""Helpers for calling exported functions from gwca.dll.
+
+This module offers a thin wrapper around :mod:`ctypes` so Py4GW scripts can
+bind decorated exports from ``gwca.dll`` (the Guild Wars Client API library).
+The helpers only deal with obtaining the function pointer and applying the
+correct calling convention; scripts are still responsible for mapping the
+arguments and return types to matching ``ctypes`` declarations.
+"""
+from __future__ import annotations
+
+import ctypes
+from ctypes import c_bool, c_uint32, wintypes
+import threading
+import weakref
+from typing import Optional, Sequence, Union
+
+__all__ = [
+    "GWCALibrary",
+    "EncodedStringDecoder",
+    "get_shared_gwca_library",
+    "load_gwca_function",
+]
+
+
+class _CDLLNoFree(ctypes.CDLL):
+    """``ctypes.CDLL`` variant that skips ``FreeLibrary`` on GC."""
+
+    def __del__(self) -> None:  # pragma: no cover - behaviour depends on GC
+        pass
+
+
+class _WinDLLNoFree(ctypes.WinDLL):
+    """``ctypes.WinDLL`` variant that skips ``FreeLibrary`` on GC."""
+
+    def __del__(self) -> None:  # pragma: no cover - behaviour depends on GC
+        pass
+
+
+class GWCALibrary:
+    """Lightweight loader for ``gwca.dll`` exports.
+
+    Parameters
+    ----------
+    module_name:
+        Name of the DLL to load. Defaults to ``"gwca.dll"`` which is the
+        canonical name shipped with GWToolbox/Py4GW setups.
+    prefer_loaded:
+        If ``True`` (the default) and the module is already loaded inside the
+        current process the existing handle is reused. Reusing the handle avoids
+        accidentally loading a second copy of the library which would fail to
+        see Guild Wars' game state.
+    default_call_conv:
+        Either ``"cdecl"`` or ``"stdcall"``. GWCA exports are declared with
+        the default ``__cdecl`` calling convention, but the parameter is
+        exposed so that scripts can opt into ``stdcall`` when binding custom
+        hooks or third-party exports.
+    """
+
+    _init_lock = threading.Lock()
+    _global_init_result: Optional[bool] = None
+
+    def __init__(
+        self,
+        module_name: str = "gwca.dll",
+        *,
+        prefer_loaded: bool = True,
+        default_call_conv: str = "cdecl",
+    ) -> None:
+        self._module_name = module_name
+        self._kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        self._finalizer: Optional[weakref.Finalize] = None
+
+        handle_value: Optional[int] = None
+
+        if prefer_loaded:
+            existing = self._kernel32.GetModuleHandleW(module_name)
+            if existing:
+                duplicate = self._kernel32.LoadLibraryW(module_name)
+                if not duplicate:  # pragma: no cover - defensive path
+                    raise ctypes.WinError(ctypes.get_last_error())
+                handle_value = int(duplicate)
+                self._cdecl = _CDLLNoFree(None, handle=handle_value)
+                self._stdcall = _WinDLLNoFree(None, handle=handle_value)
+                self._finalizer = weakref.finalize(
+                    self,
+                    self._kernel32.FreeLibrary,
+                    wintypes.HMODULE(handle_value),
+                )
+
+        if handle_value is None:
+            # ``CDLL``/``WinDLL`` load the module if it is not already present and
+            # keep their own reference counts, so we can rely on their finalizers.
+            self._cdecl = ctypes.CDLL(module_name)
+            self._stdcall = ctypes.WinDLL(module_name)
+            handle_value = int(self._cdecl._handle)
+
+        self._handle = wintypes.HMODULE(handle_value)
+        self._default_call_conv = default_call_conv.lower()
+        self._initialized = False
+
+        if not self.initialize():
+            raise RuntimeError("GWCA::Initialize() failed")
+
+    @property
+    def handle(self) -> int:
+        """Return the raw ``HMODULE`` handle."""
+
+        return self._handle.value
+
+    def initialize(self) -> bool:
+        """Ensure ``GWCA::Initialize`` ran successfully."""
+
+        if self._initialized:
+            return True
+
+        if GWCALibrary._global_init_result is not None:
+            self._initialized = GWCALibrary._global_init_result
+            return self._initialized
+
+        with GWCALibrary._init_lock:
+            if GWCALibrary._global_init_result is None:
+                initialize = self.get_function(
+                    "?Initialize@GW@@YA_NXZ", restype=c_bool
+                )
+                GWCALibrary._global_init_result = bool(initialize())
+            self._initialized = GWCALibrary._global_init_result
+        return self._initialized
+
+    def get_function(
+        self,
+        symbol: Union[str, int],
+        *,
+        restype: Optional[ctypes._CData] = None,
+        argtypes: Sequence[ctypes._CData] | None = None,
+        call_conv: Optional[str] = None,
+    ) -> ctypes._CFuncPtr:
+        """Return a callable ctypes wrapper for an exported function.
+
+        Parameters
+        ----------
+        symbol:
+            Either the decorated export name (for example,
+            ``"?GetMapID@Map@GW@@YA?AW4MapID@Constants@2@XZ"``) or the ordinal
+            number published by the DLL (``193`` for ``GetMapID`` in the list
+            provided by GWCA).
+        restype:
+            ``ctypes`` type that describes the function's return value. ``None``
+            (the default) makes the wrapper behave like a ``void`` function.
+        argtypes:
+            Sequence describing the argument types for ``ctypes``. Providing it
+            enables automatic type conversion and stack validation.
+        call_conv:
+            Override for the calling convention. ``"cdecl"`` uses the ``CDLL``
+            binding while ``"stdcall"`` uses the ``WinDLL`` binding.
+
+        Returns
+        -------
+        ``ctypes._CFuncPtr``
+            A ready-to-use callable that can be invoked directly from Python.
+        """
+
+        binding = (call_conv or self._default_call_conv).lower()
+        if binding not in {"cdecl", "stdcall"}:
+            raise ValueError("call_conv must be either 'cdecl' or 'stdcall'")
+
+        library = self._cdecl if binding == "cdecl" else self._stdcall
+        if isinstance(symbol, int):
+            lookup = f"#{symbol}"
+        else:
+            lookup = symbol
+        try:
+            func = getattr(library, lookup)
+        except AttributeError as exc:  # pragma: no cover - defensive path
+            raise AttributeError(
+                f"Function '{symbol}' not found in {self._module_name}"
+            ) from exc
+
+        if argtypes is not None:
+            func.argtypes = list(argtypes)
+        if restype is not None:
+            func.restype = restype
+        return func
+
+
+class EncodedStringDecoder:
+    """Decode Guild Wars encoded strings via ``GW::UI::AsyncDecodeStr``.
+
+    Guild Wars stores many localized strings in an encoded wide-character
+    format.  ``gwca.dll`` exposes ``AsyncDecodeStr`` which resolves those
+    strings asynchronously on the game thread.  This helper mirrors the
+    behaviour of GWToolbox's ``GuiUtils::EncString`` so Python scripts can
+    synchronously obtain decoded text for quest names, item descriptions and
+    similar fields.
+
+    Parameters
+    ----------
+    library:
+        Active :class:`GWCALibrary` instance used to look up ``AsyncDecodeStr``.
+    timeout:
+        Maximum time in seconds to wait for each string to decode before
+        falling back to the raw encoded value.
+    language:
+        Optional ``GW::Constants::Language`` override.  The default (``0xFF``)
+        lets the client pick the currently active language.
+    """
+
+    _DecodeCallback = ctypes.CFUNCTYPE(None, ctypes.py_object, ctypes.c_wchar_p)
+
+    class _DecodeState:
+        __slots__ = ("event", "result", "encoded")
+
+        def __init__(self, encoded: ctypes.c_wchar_p) -> None:
+            self.event = threading.Event()
+            self.result: str | None = None
+            # Keep a reference to the encoded pointer object alive until the
+            # asynchronous decode finishes.
+            self.encoded = encoded
+
+    def __init__(
+        self,
+        library: GWCALibrary,
+        *,
+        timeout: float = 0.5,
+        language: int = 0xFF,
+    ) -> None:
+        self._timeout = timeout
+        self._language = language
+        self._callback = self._DecodeCallback(self._on_decoded)
+        self._decode = library.get_function(
+            "?AsyncDecodeStr@UI@GW@@YAXPB_WP6AXPAX0@Z1W4Language@Constants@2@@Z",
+            restype=None,
+            argtypes=(
+                ctypes.c_wchar_p,
+                self._DecodeCallback,
+                ctypes.py_object,
+                c_uint32,
+            ),
+        )
+        self._lock = threading.Lock()
+        self._pending: set[EncodedStringDecoder._DecodeState] = set()
+
+    def _start_decode(self, encoded: ctypes.c_wchar_p) -> _DecodeState:
+        state = self._DecodeState(encoded)
+        with self._lock:
+            self._pending.add(state)
+        try:
+            self._decode(encoded, self._callback, state, self._language)
+        except Exception:
+            with self._lock:
+                self._pending.discard(state)
+            raise
+        return state
+
+    def _on_decoded(self, state: _DecodeState, decoded: str | None) -> None:
+        state.result = decoded or ""
+        state.event.set()
+        with self._lock:
+            self._pending.discard(state)
+
+    def decode_many(self, pointers: Sequence[int | None]) -> list[str | None]:
+        """Decode multiple encoded string pointers at once."""
+
+        states: list[tuple[EncodedStringDecoder._DecodeState | None, str | None]] = []
+        for pointer in pointers:
+            if not pointer:
+                states.append((None, None))
+                continue
+            try:
+                address = int(pointer)
+            except (TypeError, ValueError):
+                address = pointer
+            encoded = ctypes.cast(ctypes.c_void_p(address), ctypes.c_wchar_p)
+            try:
+                raw_value = encoded.value
+            except (ValueError, OSError):
+                states.append((None, None))
+                continue
+            if raw_value in (None, ""):
+                states.append((None, raw_value or ""))
+                continue
+            state = self._start_decode(encoded)
+            states.append((state, raw_value))
+
+        results: list[str | None] = []
+        for state, fallback in states:
+            if state is None:
+                results.append(fallback)
+                continue
+            if state.event.wait(self._timeout) and state.result is not None:
+                results.append(state.result)
+            elif state.event.is_set() and state.result is not None:
+                results.append(state.result)
+            else:
+                results.append(fallback)
+        return results
+
+    def decode_pointer(self, pointer: int | None) -> str | None:
+        """Decode a single encoded string pointer."""
+
+        return self.decode_many([pointer])[0]
+
+
+_shared_library: Optional[GWCALibrary] = None
+_shared_library_lock = threading.Lock()
+
+
+def get_shared_gwca_library(
+    *,
+    module_name: str = "gwca.dll",
+    prefer_loaded: bool = True,
+    default_call_conv: str = "cdecl",
+) -> GWCALibrary:
+    """Return the process-wide ``GWCALibrary`` instance."""
+
+    global _shared_library
+    with _shared_library_lock:
+        if _shared_library is None:
+            _shared_library = GWCALibrary(
+                module_name=module_name,
+                prefer_loaded=prefer_loaded,
+                default_call_conv=default_call_conv,
+            )
+        else:
+            if module_name != _shared_library._module_name:
+                raise ValueError(
+                    "GWCA is already loaded for module "
+                    f"{_shared_library._module_name}, cannot switch to {module_name}"
+                )
+        return _shared_library
+
+
+def load_gwca_function(
+    symbol: Union[str, int],
+    *,
+    restype: Optional[ctypes._CData] = None,
+    argtypes: Sequence[ctypes._CData] | None = None,
+    call_conv: str = "cdecl",
+    module_name: str = "gwca.dll",
+    prefer_loaded: bool = True,
+) -> ctypes._CFuncPtr:
+    """Convenience wrapper that instantiates :class:`GWCALibrary` on demand."""
+
+    library = get_shared_gwca_library(
+        module_name=module_name,
+        prefer_loaded=prefer_loaded,
+        default_call_conv="cdecl",
+    )
+    return library.get_function(
+        symbol,
+        restype=restype,
+        argtypes=argtypes,
+        call_conv=call_conv,
+    )

--- a/Py4GWCoreLib/GWCA.py
+++ b/Py4GWCoreLib/GWCA.py
@@ -10,8 +10,8 @@ from __future__ import annotations
 
 import ctypes
 from ctypes import c_bool, c_uint32, wintypes
+from pathlib import Path
 import threading
-import weakref
 from typing import Optional, Sequence, Union
 
 __all__ = [
@@ -68,30 +68,49 @@ class GWCALibrary:
     ) -> None:
         self._module_name = module_name
         self._kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
-        self._finalizer: Optional[weakref.Finalize] = None
+        self._kernel32.GetModuleHandleW.argtypes = [wintypes.LPCWSTR]
+        self._kernel32.GetModuleHandleW.restype = wintypes.HMODULE
+        self._kernel32.LoadLibraryW.argtypes = [wintypes.LPCWSTR]
+        self._kernel32.LoadLibraryW.restype = wintypes.HMODULE
+        self._kernel32.FreeLibrary.argtypes = [wintypes.HMODULE]
+        self._kernel32.FreeLibrary.restype = wintypes.BOOL
+        self._kernel32.GetModuleFileNameW.argtypes = [
+            wintypes.HMODULE,
+            wintypes.LPWSTR,
+            wintypes.DWORD,
+        ]
+        self._kernel32.GetModuleFileNameW.restype = wintypes.DWORD
 
         handle_value: Optional[int] = None
 
         if prefer_loaded:
-            existing = self._kernel32.GetModuleHandleW(module_name)
-            if existing:
-                duplicate = self._kernel32.LoadLibraryW(module_name)
-                if not duplicate:  # pragma: no cover - defensive path
-                    raise ctypes.WinError(ctypes.get_last_error())
-                handle_value = int(duplicate)
-                self._cdecl = _CDLLNoFree(None, handle=handle_value)
-                self._stdcall = _WinDLLNoFree(None, handle=handle_value)
-                self._finalizer = weakref.finalize(
-                    self,
-                    self._kernel32.FreeLibrary,
-                    wintypes.HMODULE(handle_value),
-                )
+            existing_handle, module_path = self._find_loaded_module(module_name)
+            if existing_handle:
+                if module_path:
+                    try:
+                        cdecl = ctypes.CDLL(module_path)
+                        stdcall = ctypes.WinDLL(module_path)
+                    except OSError:
+                        pass
+                    else:
+                        self._cdecl = cdecl
+                        self._stdcall = stdcall
+                        handle_value = int(cdecl._handle)
+                if handle_value is None:
+                    handle_value = existing_handle
+                    self._cdecl = _CDLLNoFree(None, handle=handle_value)
+                    self._stdcall = _WinDLLNoFree(None, handle=handle_value)
 
         if handle_value is None:
             # ``CDLL``/``WinDLL`` load the module if it is not already present and
             # keep their own reference counts, so we can rely on their finalizers.
-            self._cdecl = ctypes.CDLL(module_name)
-            self._stdcall = ctypes.WinDLL(module_name)
+            try:
+                self._cdecl = ctypes.CDLL(module_name)
+                self._stdcall = ctypes.WinDLL(module_name)
+            except OSError as exc:
+                raise FileNotFoundError(
+                    f"Could not locate {module_name}. Inject gwca.dll or provide an absolute path."
+                ) from exc
             handle_value = int(self._cdecl._handle)
 
         self._handle = wintypes.HMODULE(handle_value)
@@ -180,6 +199,36 @@ class GWCALibrary:
         if restype is not None:
             func.restype = restype
         return func
+
+    def _find_loaded_module(self, module_name: str) -> tuple[Optional[int], Optional[str]]:
+        """Return an existing module handle and its on-disk path if available."""
+
+        candidates: list[str] = []
+        base = Path(module_name).name
+        for name in (module_name, base, base.lower(), base.upper()):
+            if name and name not in candidates:
+                candidates.append(name)
+
+        for candidate in candidates:
+            handle = self._kernel32.GetModuleHandleW(candidate)
+            if handle:
+                win_handle = wintypes.HMODULE(handle)
+                path = self._get_module_path(win_handle)
+                return int(win_handle.value), path
+        return None, None
+
+    def _get_module_path(self, handle: wintypes.HMODULE) -> Optional[str]:
+        """Resolve the filesystem path for a loaded module handle."""
+
+        buffer_length = 260
+        while True:
+            buffer = ctypes.create_unicode_buffer(buffer_length)
+            written = self._kernel32.GetModuleFileNameW(handle, buffer, buffer_length)
+            if written == 0:
+                return None
+            if written < buffer_length - 1:
+                return buffer.value
+            buffer_length *= 2
 
 
 class EncodedStringDecoder:

--- a/Py4GWCoreLib/__init__.py
+++ b/Py4GWCoreLib/__init__.py
@@ -46,6 +46,12 @@ from .Effect import *
 from .Merchant import *
 from .Quest import *
 from .Camera import *
+from .GWCA import (
+    EncodedStringDecoder,
+    GWCALibrary,
+    get_shared_gwca_library,
+    load_gwca_function,
+)
 
 from .Py4GWcorelib import *
 from .Overlay import *

--- a/docs/gwca_function_calls.md
+++ b/docs/gwca_function_calls.md
@@ -1,0 +1,148 @@
+# Calling functions exported by `gwca.dll`
+
+When the Guild Wars client has `gwca.dll` injected you can call any of its
+exports from a Py4GW script.  The new `Py4GWCoreLib.GWCA` helper removes the
+boilerplate usually required to bind decorated C++ exports with `ctypes`.
+
+## 1. Load the library and call `Initialize`
+
+```python
+from Py4GWCoreLib import get_shared_gwca_library
+
+gwca = get_shared_gwca_library()  # shared singleton used by every widget/script
+gwca.initialize()                 # runs GWCA::Initialize only once per process
+```
+
+`get_shared_gwca_library()` returns a process-wide singleton so every Py4GW
+widget and script talks to the same `GWCALibrary` instance. The helper acquires
+its own reference to the already injected module to keep it loaded and protects
+against accidentally calling `FreeLibrary` on Guild Wars’ copy.【F:Py4GWCoreLib/GWCA.py†L21-L118】
+During construction the loader wires up `GWCA::Initialize`; the first caller
+triggers the scan while subsequent ones simply reuse the cached result.【F:Py4GWCoreLib/GWCA.py†L120-L160】
+
+If you only need a single function you can call `load_gwca_function(...)`
+instead. It reuses the shared instance under the hood and returns the bound
+callable.【F:Py4GWCoreLib/GWCA.py†L205-L235】
+
+## 2. Bind the function you need
+
+Pass either the decorated export name or the ordinal from your dump together
+with the expected signature:
+
+```python
+from ctypes import c_bool, c_uint32
+
+# Using the decorated name
+destroy_item = gwca.get_function(
+    "?DestroyItem@Items@GW@@YA_NI@Z",
+    restype=c_bool,
+    argtypes=(c_uint32,),
+)
+
+# Using the ordinal number (466 == UseSkill in the table you provided)
+use_skill = gwca.get_function(
+    466,
+    restype=c_bool,
+    argtypes=(c_uint32, c_uint32),
+)
+```
+
+The helper accepts either `cdecl` (GWCA’s default) or `stdcall` bindings and
+exposes them via the `call_conv` parameter when needed.【F:Py4GWCoreLib/GWCA.py†L162-L204】
+
+## 3. Call the function inside your script
+
+```python
+item_id = 0x12345678
+if destroy_item(item_id):
+    print(f"Destroyed item {item_id:#x}")
+
+skill_id = 5
+current_target = 0  # use 0 to keep the current target
+gwca.Console.Log("demo", f"Use skill {skill_id}")
+use_skill(skill_id, current_target)
+```
+
+Because the return value and parameter types are backed by `ctypes`, Python
+will automatically marshal integral values for you. For pointers or structures
+create the corresponding `ctypes` definitions before binding the function. For
+example, the quest demo maps `GW::Quest` and its nested `GW::GamePos` before
+calling `GW::QuestMgr::GetQuest`:
+
+```python
+import ctypes
+from ctypes import POINTER, Structure, c_float, c_uint32, c_void_p
+
+
+class GamePos(Structure):
+    _fields_ = [
+        ("x", c_float),
+        ("y", c_float),
+        ("plane", c_float),
+    ]
+
+
+class QuestStruct(Structure):
+    _fields_ = [
+        ("quest_id", c_uint32),
+        ("log_state", c_uint32),
+        ("location", c_void_p),
+        ("name", c_void_p),
+        ("npc", c_void_p),
+        ("map_from", c_uint32),
+        ("marker", GamePos),
+        ("_unknown_0x24", c_uint32),
+        ("map_to", c_uint32),
+        ("description", c_void_p),
+        ("objectives", c_void_p),
+    ]
+
+
+get_quest = gwca.get_function(
+    "?GetQuest@QuestMgr@GW@@YAPAUQuest@2@W4QuestID@Constants@2@@Z",
+    restype=POINTER(QuestStruct),
+    argtypes=(c_uint32,),
+)
+quest_ptr = get_quest(quest_id)
+if quest_ptr:
+    quest = quest_ptr.contents
+    quest_name = ctypes.wstring_at(quest.name) if quest.name else None
+```
+
+## 4. Decode encoded strings returned by Guild Wars
+
+Many fields exposed by GWCA (quest names, item descriptions, agent names,
+etc.) are stored as encoded ``wchar_t`` buffers inside the client.  Toolbox
+wraps them in ``GuiUtils::EncString`` so the Guild Wars UI thread can decode
+the localized text asynchronously.  ``Py4GWCoreLib.GWCA`` now provides a
+matching :class:`EncodedStringDecoder` helper that mirrors this behaviour:
+
+```python
+from Py4GWCoreLib import EncodedStringDecoder, GWCALibrary
+
+gwca = GWCALibrary()
+decoder = EncodedStringDecoder(gwca)
+
+quest = get_quest(quest_id).contents
+name, description = decoder.decode_many([
+    int(quest.name) if quest.name else None,
+    int(quest.description) if quest.description else None,
+])
+```
+
+The helper queues ``GW::UI::AsyncDecodeStr`` calls and waits briefly for the
+callback so scripts receive human-readable strings inside the same frame.
+Fallback logic keeps the encoded text available if decoding takes longer than
+expected.【F:Py4GWCoreLib/GWCA.py†L142-L257】
+
+## Tips
+
+* Keep using the Py4GW helper APIs (agents, inventory, etc.) whenever they
+  already expose the behaviour you need. Drop down to `gwca.dll` only for
+  features that have not been wrapped yet.
+* Many GWCA exports expect to be executed on the Guild Wars game thread. Use
+  the existing `GameThread` utilities from Py4GW when you need to enqueue work
+  there before calling into GWCA.
+* Invalid signatures or incorrect calling conventions typically crash the
+  Guild Wars client. Double-check the parameters against the GWCA headers in
+  `external/GWToolboxpp/Dependencies/GWCA/include` when in doubt.


### PR DESCRIPTION
## Summary
- add an EncodedStringDecoder helper that mirrors GWToolbox's GuiUtils::EncString by driving GW::UI::AsyncDecodeStr from Python
- expose the decoder through Py4GWCoreLib and update the GWCA quest demo to resolve quest fields with it before logging
- extend the GWCA function guide with instructions for decoding encoded strings via the new helper
- ensure GWCALibrary keeps a shared, process-wide instance that retains its own gwca.dll reference so scripts reuse a single initialization
- normalize code and documentation references to use the lowercase gwca.dll module name consistently

## Testing
- python -m compileall Py4GWCoreLib/GWCA.py DEMO/DEMO_GWCA_Quest_Demo.py

------
https://chatgpt.com/codex/tasks/task_e_68dd7eae92e8832ebe430705240ccd4d