### PR TITLE
Update GWCA loader default path to bundled DLL

### DIFF
--- a/Py4GWCoreLib/GWCA.py
+++ b/Py4GWCoreLib/GWCA.py
@@ -13,13 +13,23 @@ from ctypes import c_bool, c_uint32, wintypes
 import threading
 import weakref
 from typing import Optional, Sequence, Union
+from pathlib import Path
 
 __all__ = [
+    "DEFAULT_GWCA_MODULE",
     "GWCALibrary",
     "EncodedStringDecoder",
     "get_shared_gwca_library",
     "load_gwca_function",
 ]
+
+
+_REPO_GWCA_PATH = (
+    Path(__file__).resolve().parent.parent / "Addons" / "GWToolboxpp" / "gwca.dll"
+)
+DEFAULT_GWCA_MODULE = (
+    str(_REPO_GWCA_PATH) if _REPO_GWCA_PATH.exists() else "gwca.dll"
+)
 
 
 class _CDLLNoFree(ctypes.CDLL):
@@ -42,8 +52,9 @@ class GWCALibrary:
     Parameters
     ----------
     module_name:
-        Name of the DLL to load. Defaults to ``"gwca.dll"`` which is the
-        canonical name shipped with GWToolbox/Py4GW setups.
+        Name of the DLL to load. Defaults to the repository's bundled
+        ``gwca.dll`` (``Addons/GWToolboxpp/gwca.dll``). If that file is not
+        present the loader falls back to ``"gwca.dll"``.
     prefer_loaded:
         If ``True`` (the default) and the module is already loaded inside the
         current process the existing handle is reused. Reusing the handle avoids
@@ -61,7 +72,7 @@ class GWCALibrary:
 
     def __init__(
         self,
-        module_name: str = "gwca.dll",
+        module_name: str = DEFAULT_GWCA_MODULE,
         *,
         prefer_loaded: bool = True,
         default_call_conv: str = "cdecl",
@@ -306,7 +317,7 @@ _shared_library_lock = threading.Lock()
 
 def get_shared_gwca_library(
     *,
-    module_name: str = "gwca.dll",
+    module_name: str = DEFAULT_GWCA_MODULE,
     prefer_loaded: bool = True,
     default_call_conv: str = "cdecl",
 ) -> GWCALibrary:
@@ -335,7 +346,7 @@ def load_gwca_function(
     restype: Optional[ctypes._CData] = None,
     argtypes: Sequence[ctypes._CData] | None = None,
     call_conv: str = "cdecl",
-    module_name: str = "gwca.dll",
+    module_name: str = DEFAULT_GWCA_MODULE,
     prefer_loaded: bool = True,
 ) -> ctypes._CFuncPtr:
     """Convenience wrapper that instantiates :class:`GWCALibrary` on demand."""


### PR DESCRIPTION
## Summary
- default the GWCA loader helpers to the repository's bundled `Addons/GWToolboxpp/gwca.dll`
- export the computed default path for reuse and document the fallback behaviour

## Testing
- python -m compileall Py4GWCoreLib/GWCA.py

------
https://chatgpt.com/codex/tasks/task_e_68ded0b1ca3c832eb3ba8c818cd18255