### PR TITLE
Use PyItem stackable flag for stackability checks

### DIFF
--- a/Py4GWCoreLib/GlobalCache/ItemCache.py
+++ b/Py4GWCoreLib/GlobalCache/ItemCache.py
@@ -603,8 +603,8 @@ class ItemCache:
         def IsStackable(self, item_id):
             item = self._parent.raw_item_array.get_item_by_id(item_id)
             if item is None:
-                return False
-            return (item.interaction & 0x80000) != 0
+                item = PyItem.PyItem(item_id)
+            return item.is_stackable
         
         def IsSparkly(self, item_id):
             item = self._parent.raw_item_array.get_item_by_id(item_id)

--- a/Py4GWCoreLib/Item.py
+++ b/Py4GWCoreLib/Item.py
@@ -365,9 +365,7 @@ class Item:
             @staticmethod
             def IsStackable(item_id):
                 """Purpose: Check if an item is stackable by its ID."""
-                #return Item.item_instance(item_id).is_stackable
-                interaction = Item.Properties.GetInteraction(item_id)
-                return (interaction & 0x80000) != 0
+                return Item.item_instance(item_id).is_stackable
 
             @staticmethod
             def IsSparkly(item_id):


### PR DESCRIPTION
## Summary
- update Item.Customization.IsStackable to rely on PyItem's is_stackable flag
- align the global item cache helper with the same stackability source, falling back to a fresh PyItem lookup when needed

## Testing
- python - <<'PY' ... (stackable checks)


------
https://chatgpt.com/codex/tasks/task_e_68dedffb0094832ea8f0a8ef8dc9ca57