### PR TITLE
Handle material storage when depositing items

### DIFF
--- a/Py4GWCoreLib/GlobalCache/InventoryCache.py
+++ b/Py4GWCoreLib/GlobalCache/InventoryCache.py
@@ -548,6 +548,16 @@ class InventoryCache:
             dye1_to_match = dye_info.dye1.ToInt()
 
         storage_bags = GetStorageBags()
+        is_material = Item.Type.IsMaterial(item_id)
+
+        if is_material:
+            try:
+                material_bag_enum = Bags.MaterialStorage
+                material_bag = PyInventory.Bag(material_bag_enum.value, material_bag_enum.name)
+                if material_bag.GetSize() > 0:
+                    storage_bags = [(material_bag_enum, material_bag)] + storage_bags
+            except Exception:
+                pass
         remaining_quantity = quantity
         moved_any = False
         model_id = self.item_cache.GetModelID(item_id)
@@ -578,6 +588,9 @@ class InventoryCache:
                                     return True
 
             # === Fill empty slots ===
+            if is_material and bag_enum == Bags.MaterialStorage:
+                continue
+
             occupied_slots = {item.slot for item in items}
             for slot in range(bag.GetSize()):
                 if slot in occupied_slots:

--- a/Py4GWCoreLib/Inventory.py
+++ b/Py4GWCoreLib/Inventory.py
@@ -519,24 +519,48 @@ class Inventory:
         """
         from .enums import Bags
         
-        def GetBags():
-            possible_bags = ItemArray.CreateBagList(Bags.Storage1, Bags.Storage2, Bags.Storage3, Bags.Storage4,
-                                                    *([Bags.Storage5] if Anniversary_panel else []),
-                                                    Bags.Storage6,Bags.Storage7,Bags.Storage8,Bags.Storage9,Bags.Storage10,
-                                                    Bags.Storage11,Bags.Storage12,Bags.Storage13,Bags.Storage14)
-        
-            # Dynamically calculate the total capacity using PyInventory.Bag
-            total_capacity = sum(
-                PyInventory.Bag(bag_enum.value, bag_enum.name).GetSize() for bag_enum in possible_bags
-            )
+        is_material = Item.Type.IsMaterial(item_id)
 
-            bags = total_capacity // 25
+        def GetBags():
+            bag_order = [
+                Bags.Storage1,
+                Bags.Storage2,
+                Bags.Storage3,
+                Bags.Storage4,
+            ]
+
+            if Anniversary_panel:
+                bag_order.append(Bags.Storage5)
+
+            bag_order.extend([
+                Bags.Storage6,
+                Bags.Storage7,
+                Bags.Storage8,
+                Bags.Storage9,
+                Bags.Storage10,
+                Bags.Storage11,
+                Bags.Storage12,
+                Bags.Storage13,
+                Bags.Storage14,
+            ])
+
+            if is_material:
+                bag_order = [Bags.MaterialStorage] + bag_order
 
             storage_bags = []
+            seen = set()
 
-            for i in range(1, bags + 1):
-                    bag = getattr(Bags, f"Storage{i}")
-                    storage_bags.append(bag)
+            for bag_enum in bag_order:
+                if bag_enum in seen:
+                    continue
+
+                try:
+                    bag = PyInventory.Bag(bag_enum.value, bag_enum.name)
+                    if bag.GetSize() > 0:
+                        storage_bags.append(bag_enum)
+                        seen.add(bag_enum)
+                except Exception:
+                    continue
 
             return storage_bags
     
@@ -575,6 +599,9 @@ class Inventory:
                                     return True
 
             # Fill empty slots
+            if is_material and bag_enum == Bags.MaterialStorage:
+                continue
+
             occupied_slots = {item.slot for item in items}
             for slot in range(size):
                 if slot in occupied_slots:


### PR DESCRIPTION
## Summary
- Detect material items when depositing to storage and prioritize the material storage bag for partial stack merges in the cached inventory helper while avoiding empty-slot drops there.
- Apply the same material-aware bag ordering and empty-slot guard in the non-cached inventory helper so materials top off dedicated stacks before general storage.

## Testing
- python -m compileall Py4GWCoreLib/GlobalCache/InventoryCache.py Py4GWCoreLib/Inventory.py

------
https://chatgpt.com/codex/tasks/task_e_68dee6ebec30832ead02105660b82fc1