### PR TITLE
Fix AllyMartialRanged target selection

### DIFF
--- a/Py4GWCoreLib/SkillManager.py
+++ b/Py4GWCoreLib/SkillManager.py
@@ -249,8 +249,8 @@ class SkillManager:
             elif target_allegiance == Skilltarget.EnemyKnockedDown:
                 v_target = Routines.Targeting.GetEnemyKnockedDown(self.get_combat_distance())
                 if v_target == 0 and not targeting_strict:
-                    v_target = nearest_enemy           
-            elif target_allegiance == Skilltarget.AllyMartialRanged:
+                    v_target = nearest_enemy
+            elif target_allegiance == Skilltarget.EnemyMartialRanged:
                 v_target = Routines.Agents.GetNearestEnemyRanged(self.get_combat_distance())
                 if v_target == 0 and not targeting_strict:
                     v_target = nearest_enemy


### PR DESCRIPTION
## Summary
- Corrected the branch in GetAppropiateTarget so EnemyMartialRanged requests use ranged enemy targeting, preventing ally-focused skills from incorrectly selecting enemies.

## Comment
In the new `GetAppropiateTarget` logic, the first branch for `Skilltarget.AllyMartialRanged` fetches `GetNearestEnemyRanged` and falls back to `nearest_enemy`. Because this `elif` executes before the later ally-targeting branch, any skill configured for `AllyMartialRanged` will always select an enemy instead of an ally, so buffs or heals using this target type will misfire or fail.



