### PR TITLE
Update mission map merchant detection to use local agent data

### DIFF
--- a/Widgets/Mission Map +.py
+++ b/Widgets/Mission Map +.py
@@ -974,17 +974,25 @@ def DrawFrame():
             rotation_angle = agent.rotation_angle
             level = agent.living_agent.level
             if level > 1:
-                #agent_name = mission_map.raw_agent_array_handler.get_name(agent.id)  if mission_map.raw_agent_array_handler is not None else ""
                 agent_name = agent.living_agent.name or ""
+                agent_name_upper = agent_name.upper()
+                if agent_name_upper in ("", "UNKNOWN", "TIMEOUT"):
+                    agent_name = ""
                 if not agent_name:
-                    if agent.living_agent.IsAgentNameReady():
-                        agent_name = agent.living_agent.GetName() or ""
+                    fetched_name = agent.living_agent.GetName() or ""
+                    fetched_name_upper = fetched_name.upper()
+                    if fetched_name_upper in ("", "UNKNOWN", "TIMEOUT"):
+                        agent_name = ""
                     else:
-                        agent.living_agent.RequestName()
-                if "MERCHANT" in agent_name.upper():
+                        agent_name = fetched_name
+                        agent_name_upper = fetched_name_upper
+                if not agent_name:
+                    agent.living_agent.RequestName()
+                    agent_name_upper = ""
+                if "MERCHANT" in agent_name_upper:
                     marker = mission_map.merchant_marker
                 else:
-                    marker = mission_map.npc_marker   
+                    marker = mission_map.npc_marker
             else: 
                 marker = mission_map.minipet_marker     
             alternate_color, size = _get_alternate_color(agent.id)

--- a/Widgets/Mission Map +.py
+++ b/Widgets/Mission Map +.py
@@ -975,7 +975,12 @@ def DrawFrame():
             level = agent.living_agent.level
             if level > 1:
                 #agent_name = mission_map.raw_agent_array_handler.get_name(agent.id)  if mission_map.raw_agent_array_handler is not None else ""
-                agent_name = GLOBAL_CACHE.Agent.GetName(agent.id)
+                agent_name = agent.living_agent.name or ""
+                if not agent_name:
+                    if agent.living_agent.IsAgentNameReady():
+                        agent_name = agent.living_agent.GetName() or ""
+                    else:
+                        agent.living_agent.RequestName()
                 if "MERCHANT" in agent_name.upper():
                     marker = mission_map.merchant_marker
                 else:


### PR DESCRIPTION
## Summary
- reuse the PyAgent instance when determining merchant markers on the mission map
- request the agent name directly when it is not yet available instead of using the global cache

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e56ce87254832ea8472e961b7757dd