### PR TITLE
Fix mega zoom overlay scaling alignment

### DIFF
--- a/Widgets/Mission Map +.py
+++ b/Widgets/Mission Map +.py
@@ -802,6 +802,7 @@ class MissionMap:
         self.renderer.world_space.set_zoom(zoom/100.0)
         self.mega_zoom_renderer.world_space.set_zoom(zoom/100.0)
         self.renderer.world_space.set_scale(self.scale_x)
+        self.mega_zoom_renderer.world_space.set_scale(self.scale_x)
         
         
         


### PR DESCRIPTION
## Summary
- ensure the mega zoom renderer updates its world space scale alongside the standard renderer so both overlays follow the interface size

## Testing
- not run (not supported in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e57daf0370832ea7b4ae94cdcba142