### PR TITLE
Add Python skill template encoding utilities

### DIFF
--- a/DEMO/SkillTemplateRoundTrip.py
+++ b/DEMO/SkillTemplateRoundTrip.py
@@ -1,0 +1,48 @@
+"""Demonstrate round-trip encoding and decoding of skill templates."""
+
+import importlib.util
+import pathlib
+import sys
+
+MODULE_PATH = pathlib.Path(__file__).resolve().parents[1] / "Py4GWCoreLib" / "SkillTemplate.py"
+spec = importlib.util.spec_from_file_location("skill_template", MODULE_PATH)
+skill_template = importlib.util.module_from_spec(spec)
+sys.modules.setdefault("skill_template", skill_template)
+assert spec.loader is not None
+spec.loader.exec_module(skill_template)
+
+AttributeEntry = skill_template.AttributeEntry
+DecodeSkillTemplate = skill_template.DecodeSkillTemplate
+EncodeSkillTemplate = skill_template.EncodeSkillTemplate
+SkillTemplate = skill_template.SkillTemplate
+
+
+def main() -> None:
+    original_code = "OQASEDqEC1vcNABWAAAA"
+    template = DecodeSkillTemplate(original_code)
+
+    print("Decoded template:")
+    print(f"  Primary profession: {template.primary}")
+    print(f"  Secondary profession: {template.secondary}")
+    print("  Attributes:")
+    for entry in template.attributes:
+        print(f"    - Attribute {entry.attribute}: {entry.points} points")
+    print("  Skills:")
+    for slot, skill_id in enumerate(template.skills, start=1):
+        print(f"    {slot}: {skill_id}")
+
+    # Modify one of the values just to prove the encoder accepts manual input.
+    updated = SkillTemplate(
+        primary=template.primary,
+        secondary=template.secondary,
+        attributes=template.attributes + [AttributeEntry(attribute=1, points=3)],
+        skills=template.skills,
+    )
+
+    encoded_again = EncodeSkillTemplate(updated)
+    print("\nRe-encoded template (with an extra attribute entry):")
+    print(f"  {encoded_again}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/Py4GWCoreLib/GlobalCache/SkillbarCache.py
+++ b/Py4GWCoreLib/GlobalCache/SkillbarCache.py
@@ -1,4 +1,5 @@
 import PySkillbar
+from typing import Optional
 from Py4GWCoreLib.Py4GWcorelib import ActionQueueManager
 
 class SkillbarCache:
@@ -17,15 +18,81 @@ class SkillbarCache:
         
     def GetSkillIDBySlot(self, slot):
         return self._skillbar_instance.GetSkill(slot).id.id
-    
+
     def GetSkillbar(self):
         skill_ids = []
         for slot in range(1, 9):  # Loop through skill slots 1 to 8
             skill_id = self.GetSkillIDBySlot(slot)
             if skill_id != 0:
                 skill_ids.append(skill_id)
-                
+
         return skill_ids
+
+    def EncodeSkillTemplate(
+        self,
+        hero_index: Optional[int] = None,
+        primary: Optional[int] = None,
+        secondary: Optional[int] = None,
+        attributes=None,
+        skill_ids=None,
+    ) -> str:
+        """Encode the specified skillbar into a Guild Wars build string."""
+
+        from Py4GWCoreLib.SkillTemplate import SkillTemplate, encode_skill_template
+
+        try:
+            from Py4GWCoreLib import GLOBAL_CACHE as global_cache
+        except ImportError:  # pragma: no cover - defensive path
+            global_cache = None
+
+        resolved_skills = list(skill_ids) if skill_ids is not None else None
+        agent_id = None
+
+        if hero_index and hero_index > 0:
+            hero_skills = self._skillbar_instance.GetHeroSkillbar(hero_index) or []
+            if resolved_skills is None:
+                resolved_skills = [skill.id.id for skill in hero_skills]
+            if global_cache is not None:
+                agent_id = global_cache.Party.Heroes.GetHeroAgentIDByPartyPosition(hero_index)
+                if not agent_id and hero_index > 0:
+                    agent_id = global_cache.Party.Heroes.GetHeroAgentIDByPartyPosition(hero_index - 1)
+        else:
+            if resolved_skills is None:
+                resolved_skills = [
+                    self._skillbar_instance.GetSkill(slot).id.id
+                    for slot in range(1, 9)
+                ]
+            if global_cache is not None:
+                agent_id = global_cache.Player.GetAgentID()
+
+        resolved_attributes = list(attributes) if attributes is not None else None
+        resolved_primary = primary
+        resolved_secondary = secondary
+
+        if global_cache is not None and agent_id:
+            if resolved_primary is None or resolved_secondary is None:
+                prof1, prof2 = global_cache.Agent.GetProfessionIDs(agent_id)
+                if resolved_primary is None:
+                    resolved_primary = prof1
+                if resolved_secondary is None:
+                    resolved_secondary = prof2
+            if resolved_attributes is None:
+                resolved_attributes = list(global_cache.Agent.GetAttributes(agent_id) or [])
+
+        if resolved_skills is None:
+            raise RuntimeError("Unable to resolve skill ids for template encoding")
+        if resolved_primary is None or resolved_secondary is None:
+            raise RuntimeError("Primary and secondary professions are required to encode a template")
+        if resolved_attributes is None:
+            resolved_attributes = []
+
+        template = SkillTemplate(
+            primary=resolved_primary,
+            secondary=resolved_secondary,
+            attributes=resolved_attributes,
+            skills=resolved_skills,
+        )
+        return encode_skill_template(template)
     
     def GetHeroSkillbar(self, hero_index):
         hero_skillbar = self._skillbar_instance.GetHeroSkillbar(hero_index)

--- a/Py4GWCoreLib/SkillTemplate.py
+++ b/Py4GWCoreLib/SkillTemplate.py
@@ -1,0 +1,206 @@
+"""Utilities for working with Guild Wars skill templates.
+
+This module provides a pure Python implementation of the bit packing logic
+used by GWToolbox and GWCA to encode and decode skill templates.  The code is
+heavily inspired by the original C++ implementation located in
+``Dependencies/GWCA/Source/SkillbarMgr.cpp`` but exposes a Python friendly API
+that can be used by bots and widgets without touching the native layer.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Sequence
+
+BASE64_TABLE = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+BASE64_TO_VALUE = {ch: idx for idx, ch in enumerate(BASE64_TABLE)}
+
+TEMPLATE_HEADER = 14
+TEMPLATE_VERSION = 0
+
+MAX_SKILL_SLOTS = 8
+MAX_ATTRIBUTE_ENTRIES = 16
+# Value taken from ``Py4GWCoreLib/enums_src/GameData_enums.py``.
+ATTRIBUTE_NONE_ID = 45
+
+
+@dataclass(slots=True)
+class AttributeEntry:
+    """Represents a single attribute investment entry."""
+
+    attribute: int
+    points: int
+
+
+@dataclass(slots=True)
+class SkillTemplate:
+    """Container describing a build template."""
+
+    primary: int = 0
+    secondary: int = 0
+    attributes: List[AttributeEntry] = field(default_factory=list)
+    skills: List[int] = field(default_factory=list)
+
+    def normalized(self) -> "SkillTemplate":
+        """Return a normalized copy of the template.
+
+        The normalization step ensures the skill list contains exactly eight
+        entries (padded with zeros), filters out zero-point attribute entries,
+        and clamps obvious out-of-range values.
+        """
+
+        attrs: list[AttributeEntry] = []
+        for entry in self.attributes:
+            attr_id = int(getattr(entry, "attribute", getattr(entry, "attribute_id", entry[0] if isinstance(entry, (list, tuple)) and entry else 0)))
+            points = int(getattr(entry, "points", getattr(entry, "level_base", getattr(entry, "level", entry[1] if isinstance(entry, (list, tuple)) and len(entry) > 1 else 0))))
+            if attr_id == ATTRIBUTE_NONE_ID:
+                continue
+            if points <= 0:
+                continue
+            attrs.append(AttributeEntry(attribute=attr_id, points=points))
+            if len(attrs) >= MAX_ATTRIBUTE_ENTRIES:
+                break
+
+        skills = [int(skill) if skill else 0 for skill in self.skills[:MAX_SKILL_SLOTS]]
+        if len(skills) < MAX_SKILL_SLOTS:
+            skills.extend([0] * (MAX_SKILL_SLOTS - len(skills)))
+
+        return SkillTemplate(
+            primary=int(self.primary or 0),
+            secondary=int(self.secondary or 0),
+            attributes=attrs,
+            skills=skills,
+        )
+
+
+def _write_bits(buffer: List[int], value: int, count: int) -> None:
+    for i in range(count):
+        buffer.append((value >> i) & 1)
+
+
+def _read_bits(bits: Sequence[int], offset: int, count: int) -> tuple[int, int]:
+    if offset + count > len(bits):
+        raise ValueError("Not enough bits remaining to satisfy read request")
+    value = 0
+    for i in range(count):
+        value |= (bits[offset + i] << i)
+    return value, offset + count
+
+
+def encode_skill_template(template: SkillTemplate) -> str:
+    """Encode a :class:`SkillTemplate` into a Guild Wars build string."""
+
+    normalized = template.normalized()
+
+    bits: list[int] = []
+    _write_bits(bits, TEMPLATE_HEADER, 4)
+    _write_bits(bits, TEMPLATE_VERSION, 4)
+
+    # Professions
+    bits_per_prof = max(4, normalized.primary.bit_length(), normalized.secondary.bit_length())
+    if bits_per_prof % 2:
+        bits_per_prof += 1
+    bits_per_prof = max(bits_per_prof, 4)
+    prof_code = (bits_per_prof - 4) // 2
+    _write_bits(bits, prof_code, 2)
+    _write_bits(bits, normalized.primary, bits_per_prof)
+    _write_bits(bits, normalized.secondary, bits_per_prof)
+
+    # Attributes
+    if normalized.attributes:
+        bits_per_attr = max(4, max(entry.attribute.bit_length() for entry in normalized.attributes))
+    else:
+        bits_per_attr = 4
+    _write_bits(bits, len(normalized.attributes), 4)
+    _write_bits(bits, bits_per_attr - 4, 4)
+    for entry in normalized.attributes:
+        _write_bits(bits, entry.attribute, bits_per_attr)
+        _write_bits(bits, entry.points, 4)
+
+    # Skills
+    bits_per_skill = max(8, max((skill.bit_length() for skill in normalized.skills), default=0))
+    _write_bits(bits, bits_per_skill - 8, 4)
+    for skill in normalized.skills:
+        _write_bits(bits, skill, bits_per_skill)
+
+    # Pad to 6 bits and encode as base64
+    remainder = len(bits) % 6
+    if remainder:
+        for _ in range(6 - remainder):
+            bits.append(0)
+
+    result_chars: list[str] = []
+    for i in range(0, len(bits), 6):
+        value = 0
+        for j in range(6):
+            value |= (bits[i + j] << j)
+        result_chars.append(BASE64_TABLE[value])
+
+    return "".join(result_chars)
+
+
+def decode_skill_template(build_code: str) -> SkillTemplate:
+    """Decode a Guild Wars build string into a :class:`SkillTemplate`."""
+
+    bit_stream: list[int] = []
+    for ch in build_code.strip():
+        if ch not in BASE64_TO_VALUE:
+            raise ValueError(f"Invalid base64 character '{ch}' in template")
+        numeric_value = BASE64_TO_VALUE[ch]
+        _write_bits(bit_stream, numeric_value, 6)
+
+    offset = 0
+    header, offset = _read_bits(bit_stream, offset, 4)
+    if header not in (0, TEMPLATE_HEADER):
+        raise ValueError(f"Unsupported template header: {header}")
+    if header == TEMPLATE_HEADER:
+        # Skip version
+        _, offset = _read_bits(bit_stream, offset, 4)
+
+    bits_per_prof_code, offset = _read_bits(bit_stream, offset, 2)
+    bits_per_prof = bits_per_prof_code * 2 + 4
+    primary, offset = _read_bits(bit_stream, offset, bits_per_prof)
+    secondary, offset = _read_bits(bit_stream, offset, bits_per_prof)
+
+    attrib_count, offset = _read_bits(bit_stream, offset, 4)
+    bits_per_attr_offset, offset = _read_bits(bit_stream, offset, 4)
+    bits_per_attr = bits_per_attr_offset + 4
+    attributes: list[AttributeEntry] = []
+    for _ in range(min(attrib_count, MAX_ATTRIBUTE_ENTRIES)):
+        attribute_id, offset = _read_bits(bit_stream, offset, bits_per_attr)
+        points, offset = _read_bits(bit_stream, offset, 4)
+        if points <= 0 or attribute_id == ATTRIBUTE_NONE_ID:
+            continue
+        attributes.append(AttributeEntry(attribute=attribute_id, points=points))
+
+    bits_per_skill_offset, offset = _read_bits(bit_stream, offset, 4)
+    bits_per_skill = bits_per_skill_offset + 8
+    skills: list[int] = []
+    for _ in range(MAX_SKILL_SLOTS):
+        if offset + bits_per_skill > len(bit_stream):
+            break
+        skill_id, offset = _read_bits(bit_stream, offset, bits_per_skill)
+        skills.append(skill_id)
+    if len(skills) < MAX_SKILL_SLOTS:
+        skills.extend([0] * (MAX_SKILL_SLOTS - len(skills)))
+
+    return SkillTemplate(primary=primary, secondary=secondary, attributes=attributes, skills=skills)
+
+
+# Convenience aliases using the naming convention from the native layer.
+def EncodeSkillTemplate(template: SkillTemplate) -> str:
+    return encode_skill_template(template)
+
+
+def DecodeSkillTemplate(build_code: str) -> SkillTemplate:
+    return decode_skill_template(build_code)
+
+
+__all__ = [
+    "AttributeEntry",
+    "SkillTemplate",
+    "EncodeSkillTemplate",
+    "DecodeSkillTemplate",
+    "encode_skill_template",
+    "decode_skill_template",
+]

--- a/Py4GWCoreLib/Skillbar.py
+++ b/Py4GWCoreLib/Skillbar.py
@@ -2,6 +2,64 @@ import PySkillbar
 
 class SkillBar:
     @staticmethod
+    def EncodeSkillTemplate(
+        skill_ids=None,
+        attributes=None,
+        primary=None,
+        secondary=None,
+        hero_index=None,
+    ):
+        """Encode the current (or provided) skillbar into a template string.
+
+        Args:
+            skill_ids: Optional iterable of up to eight skill ids.  When not
+                provided the function will attempt to read the ids from the
+                live client via :mod:`GLOBAL_CACHE`.
+            attributes: Optional collection describing attribute investment.
+                Entries can either be :class:`AttributeEntry` objects,
+                ``(attribute_id, points)`` tuples, or PyAgent attribute
+                structures.
+            primary: Optional primary profession id.  When omitted the value is
+                resolved from the active agent.
+            secondary: Optional secondary profession id.  When omitted the
+                value is resolved from the active agent.
+            hero_index: Optional hero index (1-based) whose skillbar should be
+                encoded.  When omitted the player skillbar is used.
+        """
+
+        from Py4GWCoreLib.SkillTemplate import SkillTemplate, encode_skill_template
+
+        if skill_ids is not None and primary is not None and secondary is not None:
+            template = SkillTemplate(
+                primary=primary,
+                secondary=secondary,
+                attributes=list(attributes or []),
+                skills=list(skill_ids),
+            )
+            return encode_skill_template(template)
+
+        try:  # Lazy import to avoid circular dependency at module import time.
+            from Py4GWCoreLib import GLOBAL_CACHE
+        except ImportError as exc:  # pragma: no cover - defensive path
+            raise RuntimeError("GLOBAL_CACHE is not available") from exc
+
+        return GLOBAL_CACHE.SkillBar.EncodeSkillTemplate(
+            hero_index=hero_index,
+            primary=primary,
+            secondary=secondary,
+            attributes=attributes,
+            skill_ids=skill_ids,
+        )
+
+    @staticmethod
+    def DecodeSkillTemplate(build_code):
+        """Decode a template string into a :class:`SkillTemplate` instance."""
+
+        from Py4GWCoreLib.SkillTemplate import decode_skill_template
+
+        return decode_skill_template(build_code)
+
+    @staticmethod
     def LoadSkillTemplate(skill_template):
         """
         Purpose: Load a skill template by name.

--- a/Py4GWCoreLib/__init__.py
+++ b/Py4GWCoreLib/__init__.py
@@ -41,6 +41,7 @@ from .Item import *
 from .ItemArray import *
 from .Inventory import *
 from .Skill import *
+from .SkillTemplate import *
 from .Skillbar import *
 from .Effect import *
 from .Merchant import *

--- a/tests/test_skill_template.py
+++ b/tests/test_skill_template.py
@@ -1,0 +1,79 @@
+import importlib.util
+import pathlib
+import sys
+import unittest
+
+MODULE_PATH = pathlib.Path(__file__).resolve().parents[1] / "Py4GWCoreLib" / "SkillTemplate.py"
+spec = importlib.util.spec_from_file_location("skill_template", MODULE_PATH)
+skill_template = importlib.util.module_from_spec(spec)
+sys.modules.setdefault("skill_template", skill_template)
+assert spec.loader is not None
+spec.loader.exec_module(skill_template)
+
+ATTRIBUTE_NONE_ID = skill_template.ATTRIBUTE_NONE_ID
+AttributeEntry = skill_template.AttributeEntry
+DecodeSkillTemplate = skill_template.DecodeSkillTemplate
+EncodeSkillTemplate = skill_template.EncodeSkillTemplate
+SkillTemplate = skill_template.SkillTemplate
+
+
+class DummyAttribute:
+    def __init__(self, attribute_id: int, level: int):
+        self.attribute_id = attribute_id
+        self.level_base = level
+        self.level = level
+
+
+class SkillTemplateTests(unittest.TestCase):
+    def test_round_trip_preserves_values(self):
+        template = SkillTemplate(
+            primary=3,
+            secondary=6,
+            attributes=[
+                AttributeEntry(attribute=16, points=9),
+                AttributeEntry(attribute=9, points=8),
+            ],
+            skills=[101, 202, 303, 404, 505, 606, 707, 808],
+        )
+        encoded = EncodeSkillTemplate(template)
+        decoded = DecodeSkillTemplate(encoded)
+
+        self.assertEqual(decoded.primary, template.primary)
+        self.assertEqual(decoded.secondary, template.secondary)
+        decoded_pairs = [(entry.attribute, entry.points) for entry in decoded.attributes]
+        expected_pairs = [(entry.attribute, entry.points) for entry in template.attributes]
+        self.assertEqual(decoded_pairs, expected_pairs)
+        self.assertEqual(decoded.skills, template.skills)
+
+    def test_known_template_round_trip(self):
+        build_code = "OQASEDqEC1vcNABWAAAA"
+        decoded = DecodeSkillTemplate(build_code)
+        self.assertEqual(len(decoded.skills), 8)
+        self.assertEqual(EncodeSkillTemplate(decoded), build_code)
+
+    def test_attribute_normalization(self):
+        template = SkillTemplate(
+            primary=1,
+            secondary=2,
+            attributes=[
+                DummyAttribute(attribute_id=8, level=12),
+                AttributeEntry(attribute=ATTRIBUTE_NONE_ID, points=5),
+                AttributeEntry(attribute=11, points=0),
+            ],
+            skills=[1, 2, 3],
+        )
+        encoded = EncodeSkillTemplate(template)
+        decoded = DecodeSkillTemplate(encoded)
+
+        decoded_pairs = [(entry.attribute, entry.points) for entry in decoded.attributes]
+        self.assertEqual(decoded_pairs, [(8, 12)])
+        self.assertEqual(decoded.skills[:3], [1, 2, 3])
+        self.assertEqual(len(decoded.skills), 8)
+
+    def test_invalid_character_raises(self):
+        with self.assertRaises(ValueError):
+            DecodeSkillTemplate("@@@")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- port the GWToolbox/GWCA skill template encoder/decoder logic into a pure Python module
- expose encoding helpers through SkillBar and the GLOBAL_CACHE skillbar cache so bots can emit build codes
- add unit tests and a demo script that exercises round-trip encode/decode behaviour

## Testing
- python -m unittest discover tests

------
https://chatgpt.com/codex/tasks/task_e_68e68c4d77f4832eb9a8d76c4a05a76f